### PR TITLE
Multiples générations de menu simultanées

### DIFF
--- a/app/models/communication/website/menu/with_automatism.rb
+++ b/app/models/communication/website/menu/with_automatism.rb
@@ -8,8 +8,10 @@ module Communication::Website::Menu::WithAutomatism
   def generate_automatically
     begin
       pause_git_sync
-      clear_items
-      create_items
+      transaction do
+        clear_items
+        create_items
+      end
     ensure
       unpause_git_sync
     end


### PR DESCRIPTION
Ajout d'une transaction pour éviter qu'un menu en cours de constitution crashe à cause d'une autre génération simultanée qui aurait effacé ses items en cours de route
fix #1697 