### PR TITLE
set locale in distance_of_time_in_words helper only

### DIFF
--- a/app/views/admin/communication/blocks/content/_static.html.erb
+++ b/app/views/admin/communication/blocks/content/_static.html.erb
@@ -1,11 +1,11 @@
 <%
 @university = about.university
-I18n.locale = about.language.iso_code if about.respond_to?(:language)
+locale = about.respond_to?(:language) ? about.language.iso_code : nil
 %>
 contents_reading_time:
   seconds: <%= about.contents_full_text.reading_time %>
   text: >-
-    <%= distance_of_time_in_words(0, about.contents_full_text.reading_time) %>
+    <%= distance_of_time_in_words(0, about.contents_full_text.reading_time, locale: locale) %>
 contents:
 <% about.blocks.without_heading.published.ordered.each do |block| %>
 <%= render 'admin/communication/blocks/static', block: block unless block.empty? %>


### PR DESCRIPTION
On ne change **PAS** `I18n.locale` directement, sauf à l'intérieur d'un block `I18n.with_locale`.

Ici, plutôt, on passe la locale en option du helper pour éviter tout problème