### PR TITLE
Opti sync indirect objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,9 @@ GEM
       terminal-table (>= 1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.27.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.27.0-x86_64-darwin)
       bigdecimal
       rake (>= 13)
@@ -407,6 +410,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -643,6 +648,7 @@ GEM
     zlib (2.1.1)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-23
   x86_64-linux
 

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -35,9 +35,29 @@ module Communication::Website::WithGitRepository
 
   # Synchronisation optimale d'objet indirect
   def sync_indirect_object_with_git(indirect_object)
+    all_dependencies = []
     indirect_object.direct_sources.each do |direct_source|
-      add_direct_source_to_sync(direct_source)
+      # Ne pas traiter les sources d'autres sites
+      next unless direct_source.website.id == self.id
+      # Ne pas traiter les sources non synchronisables
+      next unless direct_source.syncable?
+      # Ne pas traiter si la source directe est déjà dans le tableau de dépendances
+      next if all_dependencies.include?(direct_source)
+      all_dependencies << direct_source
+      # On passe le tableau de dépendances à la méthode recursive_dependencies
+      # pour qu'il soit capable d'early return en cas de doublon
+      all_dependencies += direct_source.recursive_dependencies(array: all_dependencies, syncable_only: true)
+      # Communication::Website::GitFile.sync self, direct_source
+      # direct_source.recursive_dependencies(syncable_only: true).each do |object|
+      #   Communication::Website::GitFile.sync self, object
+      # end
+      # On ne synchronise pas les références de l'objet direct, car on ne le modifie pas lui.
+      # On ne synchronise pas les références de l'objet dir
     end
+    all_dependencies.each do |dependency|
+      Communication::Website::GitFile.sync self, dependency
+    end
+
     git_repository.sync!
   end
 
@@ -89,16 +109,4 @@ module Communication::Website::WithGitRepository
   end
 
   protected
-
-  def add_direct_source_to_sync(direct_source)
-    # Ne pas traiter les sources d'autres sites
-    return unless direct_source.website.id == self.id
-    # Ne pas traiter les sources non synchronisables
-    return unless direct_source.syncable?
-    Communication::Website::GitFile.sync self, direct_source
-    direct_source.recursive_dependencies(syncable_only: true).each do |object|
-      Communication::Website::GitFile.sync self, object
-    end
-    # On ne synchronise pas les références de l'objet direct, car on ne le modifie pas lui.
-  end
 end

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -47,12 +47,7 @@ module Communication::Website::WithGitRepository
       # On passe le tableau de dépendances à la méthode recursive_dependencies
       # pour qu'il soit capable d'early return en cas de doublon
       all_dependencies += direct_source.recursive_dependencies(array: all_dependencies, syncable_only: true)
-      # Communication::Website::GitFile.sync self, direct_source
-      # direct_source.recursive_dependencies(syncable_only: true).each do |object|
-      #   Communication::Website::GitFile.sync self, object
-      # end
       # On ne synchronise pas les références de l'objet direct, car on ne le modifie pas lui.
-      # On ne synchronise pas les références de l'objet dir
     end
     all_dependencies.each do |dependency|
       Communication::Website::GitFile.sync self, dependency

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -37,17 +37,7 @@ module Communication::Website::WithGitRepository
   def sync_indirect_object_with_git(indirect_object)
     all_dependencies = []
     indirect_object.direct_sources.each do |direct_source|
-      # Ne pas traiter les sources d'autres sites
-      next unless direct_source.website.id == self.id
-      # Ne pas traiter les sources non synchronisables
-      next unless direct_source.syncable?
-      # Ne pas traiter si la source directe est déjà dans le tableau de dépendances
-      next if all_dependencies.include?(direct_source)
-      all_dependencies << direct_source
-      # On passe le tableau de dépendances à la méthode recursive_dependencies
-      # pour qu'il soit capable d'early return en cas de doublon
-      all_dependencies += direct_source.recursive_dependencies(array: all_dependencies, syncable_only: true)
-      # On ne synchronise pas les références de l'objet direct, car on ne le modifie pas lui.
+      all_dependencies = add_direct_source_to_sync(direct_source, array: all_dependencies)
     end
     all_dependencies.each do |dependency|
       Communication::Website::GitFile.sync self, dependency
@@ -104,4 +94,19 @@ module Communication::Website::WithGitRepository
   end
 
   protected
+
+  def add_direct_source_to_sync(direct_source, array: [])
+    # Ne pas traiter les sources d'autres sites
+    return array unless direct_source.website.id == self.id
+    # Ne pas traiter les sources non synchronisables
+    return array unless direct_source.syncable?
+    # Ne pas traiter si la source directe est déjà dans le tableau de dépendances
+    return array if array.include?(direct_source)
+    array << direct_source
+    # On passe le tableau de dépendances à la méthode recursive_dependencies
+    # pour qu'il soit capable d'early return en cas de doublon
+    array += direct_source.recursive_dependencies(array: array, syncable_only: true)
+    # On ne synchronise pas les références de l'objet direct, car on ne le modifie pas lui.
+    array
+  end
 end

--- a/app/services/git/repository.rb
+++ b/app/services/git/repository.rb
@@ -10,6 +10,7 @@ class Git::Repository
   end
 
   def add_git_file(git_file)
+    return if git_files.include?(git_file)
     puts "Adding #{git_file.path}"
     if git_files.empty?
       # The first file gives the commit name


### PR DESCRIPTION
Quand on synchronisait un objet indirect, on synchronise tous les objets directs connectés à lui et leurs dépendances.

Cependant, si 2 objets directs partageait une même dépendance, on la synchronisait 2 fois (cette dépendance + toutes ses dépendances récursives !!!)

Cette PR rajoute 2 soupapes de protection :
- La méthode `Git::Repository#add_git_file` early return si un git_file est déjà présent dans sa liste
- La méthode `Communication::Website#sync_indirect_object_with_git`:
  - ne traitera pas un objet direct déjà présent dans le tableau de dépendances
  - fait passer le tableau de dépendances dans les appels de `recursive_dependencies` pour éviter les doublons.