### PR TITLE
no component in  array of dependencies

### DIFF
--- a/app/models/concerns/with_dependencies.rb
+++ b/app/models/concerns/with_dependencies.rb
@@ -84,7 +84,7 @@ module WithDependencies
     # Si l'objet ne doit pas être ajouté on n'ajoute pas non plus ses dépendances récursives
     # C'est le fait de couper ici qui évite la boucle infinie
     return array unless dependency_should_be_added?(array, dependency, syncable_only)
-    array << dependency
+    array << dependency if dependency.is_a?(ActiveRecord::Base)
     return array if !follow_direct && dependency.try(:is_direct_object?)
     return array unless dependency.respond_to?(:recursive_dependencies)
     dependency.recursive_dependencies(array: array, syncable_only: syncable_only, follow_direct: follow_direct)


### PR DESCRIPTION
Actuellement, en appelant la méthode `recursive_dependencies`, on ajoute dans le tableau final les blocs ainsi que leurs éléments.

Cependant, ces "objets" n'étant pas exportable sur git, et n'étant pas utile dans le cas des connexions, ils n'ont aucune raison d'exister dans le tableau de dépendances.

Pour remédier à ça, il suffit de tester si la dépendance en cours est un descendant d'ActiveRecord::Base. Si c'est le cas, on l'ajoute au tableau et on continue la récursion. Si ce n'est pas le cas, on ne l'ajoute pas au tableau mais on continue quand même la récursion. Si la récursion repasse par le même bloc, un early return sera trigger car le bloc sera déjà dans le tableau de dépendances.

En prenant l'exemple d'un University::Person en production et en appelant la méthode `direct_sources_with_dependencies_for_website` utilisé dans la synchronisation des objets indirects, on passe de 3541 à 724 éléments.

En détail :

- Avant
  ```
  {"Communication::Website::Post"=>49,
   "ActiveStorage::Blob"=>399,
   "Communication::Block"=>244,
   "Communication::Block::Component::Layout"=>239,
   "Communication::Block::Component::RichText"=>870,
   "Communication::Block::Component::Image"=>488,
   "Communication::Block::Component::Text"=>838,
   "Communication::Block::Template::Gallery::Element"=>347,
   "University::Person::Author"=>2,
   "University::Person"=>2,
   "Communication::Website::Configs::DefaultContentSecurityPolicy"=>1,
   "Communication::Block::Heading"=>25,
   "Communication::Block::Component::String"=>5,
   "Communication::Block::Component::Array"=>15,
   "Communication::Block::Component::Boolean"=>2,
   "Communication::Block::Template::Datatable::Element"=>13,
   "Communication::Website::Page::Author"=>1,
   "Communication::Website::Configs::DefaultLanguages"=>1}
  ```
- Après
  ```
  {"Communication::Website::Post"=>49,
   "ActiveStorage::Blob"=>399,
   "Communication::Block"=>244,
   "University::Person::Author"=>2,
   "University::Person"=>2,
   "Communication::Website::Configs::DefaultContentSecurityPolicy"=>1,
   "Communication::Block::Heading"=>25,
   "Communication::Website::Page::Author"=>1,
   "Communication::Website::Configs::DefaultLanguages"=>1}
  ```