### PR TITLE
Réparation des clés de traduction Hugo

### DIFF
--- a/app/views/admin/application/i18n/_static.html.erb
+++ b/app/views/admin/application/i18n/_static.html.erb
@@ -1,1 +1,1 @@
-translation_key: <%= @about.static_translation_key %>
+translationKey: <%= @about.static_translation_key %>


### PR DESCRIPTION
`translation_key` devient `translationKey`