### PR TITLE
Synchronisation en multiple commits si nécessaire

### DIFF
--- a/app/models/communication/website.rb
+++ b/app/models/communication/website.rb
@@ -43,6 +43,7 @@
 #  updated_at              :datetime         not null
 #  about_id                :uuid             indexed => [about_type]
 #  default_language_id     :uuid             not null, indexed
+#  locked_by_job_id        :uuid
 #  university_id           :uuid             not null, indexed
 #
 # Indexes

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 
 ActiveRecord::Schema[7.1].define(version: 2024_05_31_082129) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -147,8 +148,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_082129) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.boolean "published", default: true
-    t.uuid "heading_id"
     t.uuid "communication_website_id"
+    t.uuid "heading_id"
     t.string "migration_identifier"
     t.index ["about_type", "about_id"], name: "index_communication_website_blocks_on_about"
     t.index ["communication_website_id"], name: "index_communication_blocks_on_communication_website_id"


### PR DESCRIPTION
Lors d'une synchro, chaque commit ne contient au maximum que 250 modifications afin d'éviter un tree trop grand et des erreurs avec l'API GitHub