### PR TITLE
Nettoyage des connexions

### DIFF
--- a/app/assets/stylesheets/admin/design-system/layout.sass
+++ b/app/assets/stylesheets/admin/design-system/layout.sass
@@ -5,7 +5,7 @@ body
     padding-left: var(--bs-gutter-x)
     padding-right: var(--bs-gutter-x)
     @media (min-width: 768px)
-        --bs-gutter-x: 4rem
+        #{--bs-gutter-x}: 4rem
 
 main
     min-height: 70vh

--- a/app/models/communication/website/page/organization.rb
+++ b/app/models/communication/website/page/organization.rb
@@ -13,7 +13,7 @@ class Communication::Website::Page::Organization < Communication::Website::Page
   end
 
   # For implicit connections, direct_source_type is "Communication::Website::Page"
-  # Whereas for explicit, it will be ""Communication::Website::Page::Organization"
+  # Whereas for explicit, it will be "Communication::Website::Page::Organization"
   def explicitly_connected_organizations
     ids = website.connections.where(
             indirect_object_type: 'University::Organization',

--- a/app/models/communication/website/page/organization.rb
+++ b/app/models/communication/website/page/organization.rb
@@ -4,11 +4,22 @@ class Communication::Website::Page::Organization < Communication::Website::Page
   def dependencies
     super +
     [website.config_default_languages] +
+    explicitly_connected_organizations
+  end
+
+  # https://developers.osuny.org/docs/admin/sites-web/git/dependencies/iteration-9/
+  def references
     website.connected_organizations.where(language_id: language_id)
   end
 
+  # For implicit connections, direct_source_type is "Communication::Website::Page"
+  # Whereas for explicit, it will be ""Communication::Website::Page::Organization"
   def explicitly_connected_organizations
-    ids = website.connections.where(indirect_object_type: 'University::Organization', direct_source_type: 'Communication::Website::Page::Organization', direct_source_id: self.id).pluck(:indirect_object_id)
+    ids = website.connections.where(
+            indirect_object_type: 'University::Organization',
+            direct_source_type: 'Communication::Website::Page::Organization',
+            direct_source_id: self.id
+          ).pluck(:indirect_object_id)
     University::Organization.where(id: ids)
   end
 

--- a/app/models/communication/website/page/person.rb
+++ b/app/models/communication/website/page/person.rb
@@ -12,7 +12,7 @@ class Communication::Website::Page::Person < Communication::Website::Page
   end
 
   # For implicit connections, direct_source_type is "Communication::Website::Page"
-  # Whereas for explicit, it will be ""Communication::Website::Page::Person"
+  # Whereas for explicit, it will be "Communication::Website::Page::Person"
   def explicitly_connected_people
     ids = website.connections.where(
             indirect_object_type: 'University::Person',

--- a/app/models/communication/website/page/person.rb
+++ b/app/models/communication/website/page/person.rb
@@ -3,11 +3,22 @@ class Communication::Website::Page::Person < Communication::Website::Page
   def dependencies
     super +
     [website.config_default_languages] +
+    explicitly_connected_people
+  end
+
+  # https://developers.osuny.org/docs/admin/sites-web/git/dependencies/iteration-9/
+  def references
     website.connected_people.where(language_id: language_id)
   end
 
+  # For implicit connections, direct_source_type is "Communication::Website::Page"
+  # Whereas for explicit, it will be ""Communication::Website::Page::Person"
   def explicitly_connected_people
-    ids = website.connections.where(indirect_object_type: 'University::Person', direct_source_type: 'Communication::Website::Page::Person', direct_source_id: self.id).pluck(:indirect_object_id)
+    ids = website.connections.where(
+            indirect_object_type: 'University::Person',
+            direct_source_type: 'Communication::Website::Page::Person',
+            direct_source_id: self.id
+          ).pluck(:indirect_object_id)
     University::Person.where(id: ids)
   end
 

--- a/app/models/communication/website/page/research_publication.rb
+++ b/app/models/communication/website/page/research_publication.rb
@@ -14,7 +14,11 @@ class Communication::Website::Page::ResearchPublication < Communication::Website
 
   def dependencies
     super +
-    [website.config_default_languages] +
+    [website.config_default_languages]
+  end
+
+  # https://developers.osuny.org/docs/admin/sites-web/git/dependencies/iteration-9/
+  def references
     website.connected_publications
   end
 

--- a/app/models/communication/website/with_connected_objects.rb
+++ b/app/models/communication/website/with_connected_objects.rb
@@ -73,9 +73,10 @@ module Communication::Website::WithConnectedObjects
       direct_source,
       direct_source_type: direct_source_type
     ) if should_connect?(indirect_object, direct_source)
+    return unless should_connect_recursive_dependencies?(indirect_object)
     indirect_object.recursive_dependencies.each do |dependency|
       connect_object dependency, direct_source
-    end if should_connect_recursive_dependencies?(indirect_object)
+    end
   end
 
   def connect_and_sync(indirect_object, direct_source, direct_source_type: nil)


### PR DESCRIPTION
- Les pages "Equipe" et "Organisations" ont en dépendances uniquement les objets explicitement connectés. Les autres passent en références
- La page "Publications" a les publications en références, non plus en dépendance.
- On corrige l'algo de connexion pour éviter de suivre les objets directs étant en dépendance de niveau 1 d'un objet direct. (Voir [itération 9](https://developers.osuny.org/docs/admin/sites-web/git/dependencies/iteration-9/))
- On ne fait plus de connexion sur les ActiveStorage Blobs car ils ne sont jamais modifiés