### PR TITLE
Récupération de la version du thème : gestion des sites non-Osuny

### DIFF
--- a/app/models/communication/website/with_theme.rb
+++ b/app/models/communication/website/with_theme.rb
@@ -1,6 +1,6 @@
 module Communication::Website::WithTheme
   extend ActiveSupport::Concern
-  
+
   included do
     scope :with_automatic_update, -> { where(autoupdate_theme: true) }
     scope :with_manual_update, -> { where(autoupdate_theme: false) }
@@ -33,7 +33,8 @@ module Communication::Website::WithTheme
   protected
 
   def current_theme_version
-    URI(theme_version_url).read
+    response = Faraday.get(theme_version_url)
+    response.status == 200 ? response.body : 'NA'
   rescue
     'NA'
   end


### PR DESCRIPTION
On vérifie que l'endpoint `/osuny-theme-version` renvoie un code 200. Si ce n'est pas le cas, on met "NA" en version