### PR TITLE
Correction de comparaison des SHAs

### DIFF
--- a/app/assets/stylesheets/admin/design-system/fonts.sass
+++ b/app/assets/stylesheets/admin/design-system/fonts.sass
@@ -28,7 +28,7 @@
     font-family: 'Adelphe'
     font-style: italic
     font-weight: normal
-    src: asset-url("adelphe/InclusiveSans-Italic.woff2") format("woff2"), url("adelphe/Adelphe-GerminalItalic.woff") format("woff")
+    src: asset-url("adelphe/Adelphe-GerminalItalic.woff2") format("woff2"), url("adelphe/Adelphe-GerminalItalic.woff") format("woff")
 
 @font-face
     font-display: swap

--- a/app/services/git/analyzer.rb
+++ b/app/services/git/analyzer.rb
@@ -72,7 +72,7 @@ class Git::Analyzer
   def synchronized_with_git?
     exists_on_git? &&                                           # File exists
     git_file.previous_path == git_file.path &&                  # at the same place
-    repository.git_sha(git_file.path) == git_file.previous_sha  # with the same content
+    repository.git_sha(git_file.path) == previous_sha  # with the same content
   end
 
 end

--- a/app/services/git/analyzer.rb
+++ b/app/services/git/analyzer.rb
@@ -58,7 +58,7 @@ class Git::Analyzer
   end
 
   def previous_sha
-    git_file.previous_sha
+    repository.previous_sha(git_file)
   end
 
   def exists_on_git?
@@ -74,5 +74,5 @@ class Git::Analyzer
     git_file.previous_path == git_file.path &&                  # at the same place
     repository.git_sha(git_file.path) == git_file.previous_sha  # with the same content
   end
-  
+
 end

--- a/app/services/git/providers/abstract.rb
+++ b/app/services/git/providers/abstract.rb
@@ -37,6 +37,10 @@ class Git::Providers::Abstract
     raise NotImplementedError
   end
 
+  def previous_sha(git_file)
+    raise NotImplemetedError
+  end
+
   def computed_sha(string)
     raise NotImplementedError
   end

--- a/app/services/git/providers/abstract.rb
+++ b/app/services/git/providers/abstract.rb
@@ -38,7 +38,7 @@ class Git::Providers::Abstract
   end
 
   def previous_sha(git_file)
-    raise NotImplemetedError
+    git_sha(git_file.previous_path)
   end
 
   def computed_sha(string)

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -98,6 +98,10 @@ class Git::Providers::Github < Git::Providers::Abstract
     client.create_commit repository, sub_commit_message, new_tree[:sha], base_commit_sha
   end
 
+  def previous_sha(git_file)
+    git_sha(path) || git_file.previous_sha
+  end
+
   def computed_sha(string)
     # Git SHA-1 is calculated from the String "blob <length>\x00<contents>"
     # Source: https://alblue.bandlem.com/2011/08/git-tip-of-week-objects.html
@@ -107,15 +111,7 @@ class Git::Providers::Github < Git::Providers::Abstract
   def git_sha(path)
     return if path.nil?
     # Try to find in stored tree to avoid multiple queries
-    return tree_item_at_path(path)&.dig(:sha)
-    begin
-      # The fast way, with no query, does not work.
-      # Let's query the API.
-      content = client.content repository, path: path
-      return content[:sha]
-    rescue
-    end
-    nil
+    tree_item_at_path(path)&.dig(:sha)
   end
 
   def valid?

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -98,10 +98,6 @@ class Git::Providers::Github < Git::Providers::Abstract
     client.create_commit repository, sub_commit_message, new_tree[:sha], base_commit_sha
   end
 
-  def previous_sha(git_file)
-    git_sha(git_file.previous_path)
-  end
-
   def computed_sha(string)
     # Git SHA-1 is calculated from the String "blob <length>\x00<contents>"
     # Source: https://alblue.bandlem.com/2011/08/git-tip-of-week-objects.html

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -99,7 +99,7 @@ class Git::Providers::Github < Git::Providers::Abstract
   end
 
   def previous_sha(git_file)
-    git_sha(path) || git_file.previous_sha
+    git_sha(git_file.previous_path) || git_file.previous_sha
   end
 
   def computed_sha(string)

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -99,7 +99,7 @@ class Git::Providers::Github < Git::Providers::Abstract
   end
 
   def previous_sha(git_file)
-    git_sha(git_file.previous_path) || git_file.previous_sha
+    git_sha(git_file.previous_path)
   end
 
   def computed_sha(string)

--- a/app/services/git/providers/gitlab.rb
+++ b/app/services/git/providers/gitlab.rb
@@ -56,10 +56,6 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
     true
   end
 
-  def previous_sha(git_file)
-    git_sha(git_file.previous_path)
-  end
-
   def computed_sha(string)
     OpenSSL::Digest::SHA256.hexdigest string
   end

--- a/app/services/git/providers/gitlab.rb
+++ b/app/services/git/providers/gitlab.rb
@@ -57,7 +57,7 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
   end
 
   def previous_sha(git_file)
-    git_sha(git_file.previous_path) || git_file.previous_sha
+    git_sha(git_file.previous_path)
   end
 
   def computed_sha(string)
@@ -65,6 +65,7 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
   end
 
   # https://gitlab.com/gitlab-org/gitlab/-/issues/23504
+  # TODO : Il faudrait, comme sur GitHub, stocker le tree pour éviter N requêtes pour N objets.
   def git_sha(path)
     begin
       file = find path

--- a/app/services/git/providers/gitlab.rb
+++ b/app/services/git/providers/gitlab.rb
@@ -56,6 +56,10 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
     true
   end
 
+  def previous_sha(git_file)
+    git_sha(git_file.previous_path) || git_file.previous_sha
+  end
+
   def computed_sha(string)
     OpenSSL::Digest::SHA256.hexdigest string
   end

--- a/app/services/git/repository.rb
+++ b/app/services/git/repository.rb
@@ -38,6 +38,10 @@ class Git::Repository
     provider.computed_sha(string)
   end
 
+  def previous_sha(git_file)
+    provider.previous_sha(git_file)
+  end
+
   def git_sha(path)
     provider.git_sha path
   end


### PR DESCRIPTION
À la synchronisation, quand on analyse un fichier, on compare 2 SHAs :
- le computed_sha : on génère en local le static du fichier et on calcule son SHA (la méthode de SHA de Github et Gitlab n'est pas la même)
- le previous_sha : Le dernier SHA synchronisé sur Git

Pour le previous_sha, on se basait uniquement sur l'attribut de l'objet GitFile. Cependant, lors des problèmes de race conditions, cela a engendré des previous_sha en DB qui ne correspondait pas à la valeur réelle sur Git.

Étant donné qu'on récupère l'intégralité du tree depuis GitHub lors de la synchronisation, on peut récupérer le véritable previous_sha depuis celui-ci avec le path du fichier.

Pour GitLab, on a une méthode qui permet de récupérer le sha d'un fichier distant depuis son path, on passe également par cette méthode.

Il faudrait aussi récupérer le tree car actuellement, pour 5 fichiers, cela engendre 5 appels API contre 1 seul pour GitHub.