### PR TITLE
Suppression d'Orthotypo au profit de LanguageTool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem "mini_magick"
 gem "octokit"
 gem "omniauth-rails_csrf_protection", "~> 1"
 gem "omniauth-saml", "~> 2"
-gem "orthotypo"#, path: '../../noesya/orthotypo'
 gem "pexels", "~> 0"
 gem "pg", "~> 1"
 gem "pghero"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,17 +135,17 @@ GEM
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.939.0)
-    aws-sdk-core (3.196.1)
+    aws-partitions (1.940.0)
+    aws-sdk-core (3.197.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.82.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-kms (1.83.0)
+      aws-sdk-core (~> 3, >= 3.197.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.151.0)
-      aws-sdk-core (~> 3, >= 3.194.0)
+    aws-sdk-s3 (1.152.0)
+      aws-sdk-core (~> 3, >= 3.197.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
@@ -166,7 +166,7 @@ GEM
       railties (>= 5.0)
     bugsnag (6.27.0)
       concurrent-ruby (~> 1.0)
-    builder (3.2.4)
+    builder (3.3.0)
     byebug (11.1.3)
     cancancan (3.3.0)
     capybara (3.40.0)
@@ -237,7 +237,7 @@ GEM
     faceted_search (3.6.2)
       font-awesome-sass
       rails (>= 5.2.0)
-    faraday (2.9.0)
+    faraday (2.9.1)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
@@ -291,13 +291,13 @@ GEM
       terminal-table (>= 1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.27.0-arm64-darwin)
+    google-protobuf (4.27.1-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.0-x86_64-darwin)
+    google-protobuf (4.27.1-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.0-x86_64-linux)
+    google-protobuf (4.27.1-x86_64-linux)
       bigdecimal
       rake (>= 13)
     hal_openscience (0.1.0)
@@ -444,9 +444,6 @@ GEM
       time
       uri
     orm_adapter (0.5.0)
-    orthotypo (1.0.4)
-      htmlentities
-      nokogiri
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
@@ -592,9 +589,9 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringio (3.1.0)
     strscan (3.1.0)
@@ -706,7 +703,6 @@ DEPENDENCIES
   octokit
   omniauth-rails_csrf_protection (~> 1)
   omniauth-saml (~> 2)
-  orthotypo
   pexels (~> 0)
   pg (~> 1)
   pg_query

--- a/app/services/static/html.rb
+++ b/app/services/static/html.rb
@@ -7,7 +7,6 @@ class Static::Html < Static::Default
       # if no whitespace in the next line html in static won't be on one line
       @prepared.gsub! "\n", ' '
       @prepared = clean_empty_paragraphs_at_beginning_and_end @prepared
-      @prepared = @prepared.ortho(locale: locale)
       # TODO ça ne doit plus être utile depuis un siècle
       @prepared.gsub! "/rails/active_storage", "#{@university.url}/rails/active_storage"  
       # clean_empty_paragraphs_at_beginning_and_end re-send \n, because of Nokogiri. 

--- a/app/services/static/text.rb
+++ b/app/services/static/text.rb
@@ -7,7 +7,6 @@ class Static::Text < Static::Default
       @prepared = @text.to_s.strip.dup
       @prepared = strip_tags @prepared
       @prepared = CGI.unescapeHTML @prepared
-      @prepared = @prepared.ortho(locale: locale)
       @prepared = indent @prepared
       @prepared = sanitize @prepared
     end


### PR DESCRIPTION
Orthotypo créait des problèmes nouveaux et n'expliquait rien.
LanguageTool laisse l'humain au centre, et explique les règles.