### PR TITLE
node lts for deuxfleurs workflow

### DIFF
--- a/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
+++ b/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
@@ -18,7 +18,7 @@ jobs:
     - name: Installation de Node
       uses: actions/setup-node@v3
       with:
-        node-version: 'latest'
+        node-version: 'lts/*'
         cache: 'yarn'
 
     - name: Installation des dépendances JavaScript


### PR DESCRIPTION
La dernière version de NodeJS (22.5.0) bloque la compilation, on bascule sur la version LTS pour éviter des instabilités