### PR TITLE
Amélioration des catégories

### DIFF
--- a/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
+++ b/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
@@ -75,7 +75,8 @@ class Admin::Communication::Websites::Portfolio::CategoriesController < Admin::C
   def category_params
     params.require(:communication_website_portfolio_category)
           .permit(
-            :name, :meta_description, :summary, :slug, 
+            :name, :meta_description, :summary, :slug,
+            :facet,
             :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit
           )
           .merge(

--- a/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
+++ b/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
@@ -76,7 +76,7 @@ class Admin::Communication::Websites::Portfolio::CategoriesController < Admin::C
     params.require(:communication_website_portfolio_category)
           .permit(
             :name, :meta_description, :summary, :slug,
-            :facet,
+            :is_facet,
             :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit
           )
           .merge(

--- a/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
+++ b/app/controllers/admin/communication/websites/portfolio/categories_controller.rb
@@ -76,7 +76,7 @@ class Admin::Communication::Websites::Portfolio::CategoriesController < Admin::C
     params.require(:communication_website_portfolio_category)
           .permit(
             :name, :meta_description, :summary, :slug,
-            :is_facet,
+            :is_taxonomy,
             :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit
           )
           .merge(

--- a/app/models/communication/block/with_html_class.rb
+++ b/app/models/communication/block/with_html_class.rb
@@ -4,8 +4,9 @@ module Communication::Block::WithHtmlClass
   included do
     before_validation :parameterize_html_class
   end
-  
+
   def html_class_prepared
+    return if html_class.blank?
     html_class.split(' ')
               .map { |klass| "block-class-#{klass}" }
               .join(' ')
@@ -14,6 +15,7 @@ module Communication::Block::WithHtmlClass
   protected
 
   def parameterize_html_class
+    return if html_class.blank?
     self.html_class = html_class.split(' ')
                                 .map { |klass| klass.parameterize }
                                 .join(' ')

--- a/app/models/communication/website/portfolio/category.rb
+++ b/app/models/communication/website/portfolio/category.rb
@@ -3,9 +3,9 @@
 # Table name: communication_website_portfolio_categories
 #
 #  id                       :uuid             not null, primary key
-#  facet                    :boolean          default(FALSE)
 #  featured_image_alt       :text
 #  featured_image_credit    :text
+#  is_facet                 :boolean          default(FALSE)
 #  is_programs_root         :boolean          default(FALSE)
 #  meta_description         :text
 #  name                     :string

--- a/app/models/communication/website/portfolio/category.rb
+++ b/app/models/communication/website/portfolio/category.rb
@@ -3,6 +3,7 @@
 # Table name: communication_website_portfolio_categories
 #
 #  id                       :uuid             not null, primary key
+#  facet                    :boolean          default(FALSE)
 #  featured_image_alt       :text
 #  featured_image_credit    :text
 #  is_programs_root         :boolean          default(FALSE)
@@ -37,6 +38,7 @@
 #  fk_rails_eed5f4b819  (university_id => universities.id)
 #
 class Communication::Website::Portfolio::Category < ApplicationRecord
+  include AsCategory
   include AsDirectObject
   include Contentful
   include Initials
@@ -48,20 +50,11 @@ class Communication::Website::Portfolio::Category < ApplicationRecord
   include WithBlobs
   include WithFeaturedImage
   include WithMenuItemTarget
-  include WithPosition
-  include WithTree
   include WithUniversity
 
-  belongs_to              :parent,
-                          class_name: 'Communication::Website::Portfolio::Category',
-                          optional: true
   belongs_to              :program,
                           class_name: 'Education::Program',
                           optional: true
-  has_many                :children,
-                          class_name: 'Communication::Website::Portfolio::Category',
-                          foreign_key: :parent_id,
-                          dependent: :destroy
   has_and_belongs_to_many :projects,
                           class_name: 'Communication::Website::Portfolio::Project',
                           join_table: :communication_website_portfolio_categories_projects,

--- a/app/models/communication/website/portfolio/category.rb
+++ b/app/models/communication/website/portfolio/category.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  featured_image_alt       :text
 #  featured_image_credit    :text
-#  is_facet                 :boolean          default(FALSE)
 #  is_programs_root         :boolean          default(FALSE)
+#  is_taxonomy              :boolean          default(FALSE)
 #  meta_description         :text
 #  name                     :string
 #  path                     :string

--- a/app/models/concerns/as_category.rb
+++ b/app/models/concerns/as_category.rb
@@ -14,15 +14,17 @@ module AsCategory
                 foreign_key: :parent_id,
                 dependent: :destroy
 
-    scope :facets, -> { root.where(is_facet: true) }
-    scope :non_facets, -> { where(is_facet: false) }
+    scope :taxonomies, -> { root.where(is_taxonomy: true) }
+    scope :free, -> { where(is_taxonomy: false) }
+
+    scope :in_taxonomy, -> (category) { where(id: category.descendants.pluck(:id)) }
   end
 
-  def possible_facet?
+  def possible_taxonomy?
     persisted? && parent_id.blank?
   end
 
-  def in_facet?
-    ancestors.detect { |category| category.is_facet }
+  def in_taxonomy?
+    ancestors.detect { |category| category.is_taxonomy }
   end
 end

--- a/app/models/concerns/as_category.rb
+++ b/app/models/concerns/as_category.rb
@@ -14,7 +14,7 @@ module AsCategory
                 foreign_key: :parent_id,
                 dependent: :destroy
 
-    scope :facets, -> { root.where(facet: true) }
+    scope :facets, -> { root.where(is_facet: true) }
     scope :non_facets, -> { root.where(facet: false) }
   end
 

--- a/app/models/concerns/as_category.rb
+++ b/app/models/concerns/as_category.rb
@@ -15,7 +15,7 @@ module AsCategory
                 dependent: :destroy
 
     scope :facets, -> { root.where(is_facet: true) }
-    scope :non_facets, -> { root.where(facet: false) }
+    scope :non_facets, -> { where(is_facet: false) }
   end
 
   def possible_facet?

--- a/app/models/concerns/as_category.rb
+++ b/app/models/concerns/as_category.rb
@@ -1,0 +1,24 @@
+module AsCategory
+  extend ActiveSupport::Concern
+
+  included do
+    include WithPosition
+    include WithTree
+
+    belongs_to  :parent,
+                class_name: self.name,
+                optional: true
+
+    has_many    :children,
+                class_name: self.name,
+                foreign_key: :parent_id,
+                dependent: :destroy
+
+    scope :facets, -> { root.where(facet: true) }
+    scope :non_facets, -> { root.where(facet: false) }
+  end
+
+  def possible_facet?
+    persisted? && parent_id.blank?
+  end
+end

--- a/app/models/concerns/as_category.rb
+++ b/app/models/concerns/as_category.rb
@@ -21,4 +21,8 @@ module AsCategory
   def possible_facet?
     persisted? && parent_id.blank?
   end
+
+  def in_facet?
+    ancestors.detect { |category| category.is_facet }
+  end
 end

--- a/app/views/admin/application/categories/_form.html.erb
+++ b/app/views/admin/application/categories/_form.html.erb
@@ -16,7 +16,7 @@
           <%= f.association :categories,
                             label_text: false,
                             as: :check_boxes,
-                            collection: categories.non_facets %>
+                            collection: collection_tree_for_checkboxes(categories.non_facets) %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/application/categories/_form.html.erb
+++ b/app/views/admin/application/categories/_form.html.erb
@@ -1,22 +1,22 @@
 <% if categories.any? %>
   <%= osuny_panel t('admin.categories.title') do %>
     <div class="row">
-      <% categories.facets.each do |facet| %>
+      <% categories.taxonomies.each do |taxonomy| %>
         <div class="col-lg-6 col-xxl-4">
-          <%= osuny_label facet %>
+          <%= osuny_label taxonomy %>
           <%= f.association :categories,
                             label_text: false,
                             as: :check_boxes,
-                            collection: facet.descendants %>
+                            collection: taxonomy.descendants %>
         </div>
       <% end %>
-      <% if categories.non_facets.any? %>
+      <% if categories.root.free.any? %>
         <div class="col-lg-6 col-xxl-4">
           <%= osuny_label t('admin.categories.other') %>
           <%= f.association :categories,
                             label_text: false,
                             as: :check_boxes,
-                            collection: collection_tree_for_checkboxes(categories.non_facets) %>
+                            collection: collection_tree_for_checkboxes(categories.free) %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/application/categories/_form.html.erb
+++ b/app/views/admin/application/categories/_form.html.erb
@@ -1,0 +1,24 @@
+<% if categories.any? %>
+  <%= osuny_panel t('admin.categories.title') do %>
+    <div class="row">
+      <% categories.facets.each do |facet| %>
+        <div class="col-lg-6 col-xxl-4">
+          <%= osuny_label facet %>
+          <%= f.association :categories,
+                            label_text: false,
+                            as: :check_boxes,
+                            collection: facet.descendants %>
+        </div>
+      <% end %>
+      <% if categories.non_facets.any? %>
+        <div class="col-lg-6 col-xxl-4">
+          <%= osuny_label t('admin.categories.other') %>
+          <%= f.association :categories,
+                            label_text: false,
+                            as: :check_boxes,
+                            collection: categories.non_facets %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -1,0 +1,30 @@
+<%
+about_categories = about.categories
+all_categories = categories.all
+facets = all_categories.facets
+non_facets = all_categories.non_facets
+%>
+<% if about_categories.any? %>
+<%= key %>:
+<% about_categories.ordered.each do |category| %>
+  - "<%= category.slug %>"
+<% end %>
+categories:
+  with_facets:
+<% facets.each do |facet| %>
+    - name: "<%= prepare_text_for_static facet.to_s %>"
+      categories:
+<% about_categories.where(parent: facet).each do |category| %>
+        - name: "<%= prepare_text_for_static category.to_s %>"
+          slug: "<%= category.slug %>"
+<% end %>
+<% end %>
+  without_facets:
+<% 
+about_categories.each do |category| 
+  next if category.in_facet?
+%>
+    - name: "<%= prepare_text_for_static category.to_s %>"
+      slug: "<%= category.slug %>"
+<% end %>
+<% end %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -1,26 +1,34 @@
 <%
 about_categories = about.categories
-taxonomies = categories_model.taxonomies.ordered
+taxonomies = categories.taxonomies.ordered
 %>
 <% if about_categories.any? %>
 <%= key %>:
 <% about_categories.ordered.each do |category| %>
   - "<%= category.slug %>"
 <% end %>
+<% 
+  if taxonomies.any? 
+%>
 taxonomies:
-<% taxonomies.each do |taxonomy| %>
+<% 
+    taxonomies.each do |taxonomy| 
+%>
   - name: "<%= prepare_text_for_static taxonomy.to_s %>"
     slug: "<%= taxonomy.slug %>"
     categories:
-<% 
-about_categories.in_taxonomy(taxonomy).each do |category| 
-  hugo = category.hugo(@website)  
+<%
+      about_categories.in_taxonomy(taxonomy).each do |category| 
+        hugo = category.hugo(@website)  
 %>
       - name: "<%= prepare_text_for_static category.to_s %>"
         permalink: "<%= hugo.permalink %>"
         file: "<%= hugo.file %>"
         path: "<%= hugo.path %>"
         slug: "<%= hugo.slug %>"
-<% end %>
-<% end %>
-<% end %>
+<% 
+      end
+    end
+  end
+end 
+%>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -1,15 +1,14 @@
 <%
 about_categories = about.categories
-all_categories = categories_model.all
-facets = all_categories.facets
-non_facets = all_categories.non_facets
+facets = categories_model.facets
+non_facets = categories_model.non_facets
 %>
 <% if about_categories.any? %>
 <%= key %>:
 <% about_categories.ordered.each do |category| %>
   - "<%= category.slug %>"
 <% end %>
-categories:
+osuny_categories:
   with_facets:
 <% facets.each do |facet| %>
     - name: "<%= prepare_text_for_static facet.to_s %>"

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -12,9 +12,15 @@ taxonomies:
   - name: "<%= prepare_text_for_static taxonomy.to_s %>"
     slug: "<%= taxonomy.slug %>"
     categories:
-<% about_categories.in_taxonomy(taxonomy).each do |category| %>
+<% 
+about_categories.in_taxonomy(taxonomy).each do |category| 
+  hugo = category.hugo(@website)  
+%>
       - name: "<%= prepare_text_for_static category.to_s %>"
-        slug: "<%= category.slug %>"
+        permalink: "<%= hugo.permalink %>"
+        file: "<%= hugo.file %>"
+        path: "<%= hugo.path %>"
+        slug: "<%= hugo.slug %>"
 <% end %>
 <% end %>
 <% end %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -13,7 +13,7 @@ osuny_categories:
 <% facets.each do |facet| %>
     - name: "<%= prepare_text_for_static facet.to_s %>"
       categories:
-<% about_categories.where(parent: facet).each do |category| %>
+<% about_categories.where(id: facet.descendants).each do |category| %>
         - name: "<%= prepare_text_for_static category.to_s %>"
           slug: "<%= category.slug %>"
 <% end %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -1,6 +1,6 @@
 <%
 about_categories = about.categories
-all_categories = categories.all
+all_categories = categories_model.all
 facets = all_categories.facets
 non_facets = all_categories.non_facets
 %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -1,7 +1,6 @@
 <%
 about_categories = about.categories
-facets = categories_model.facets
-non_facets = categories_model.non_facets
+taxonomies = categories_model.taxonomies.ordered
 %>
 <% if about_categories.any? %>
 <%= key %>:
@@ -9,10 +8,11 @@ non_facets = categories_model.non_facets
   - "<%= category.slug %>"
 <% end %>
 taxonomies:
-<% facets.each do |facet| %>
-  - name: "<%= prepare_text_for_static facet.to_s %>"
+<% taxonomies.each do |taxonomy| %>
+  - name: "<%= prepare_text_for_static taxonomy.to_s %>"
+    slug: "<%= taxonomy.slug %>"
     categories:
-<% about_categories.where(id: facet.descendants).each do |category| %>
+<% about_categories.in_taxonomy(taxonomy).each do |category| %>
       - name: "<%= prepare_text_for_static category.to_s %>"
         slug: "<%= category.slug %>"
 <% end %>

--- a/app/views/admin/application/categories/_static.html.erb
+++ b/app/views/admin/application/categories/_static.html.erb
@@ -8,22 +8,13 @@ non_facets = categories_model.non_facets
 <% about_categories.ordered.each do |category| %>
   - "<%= category.slug %>"
 <% end %>
-osuny_categories:
-  with_facets:
+taxonomies:
 <% facets.each do |facet| %>
-    - name: "<%= prepare_text_for_static facet.to_s %>"
-      categories:
+  - name: "<%= prepare_text_for_static facet.to_s %>"
+    categories:
 <% about_categories.where(id: facet.descendants).each do |category| %>
-        - name: "<%= prepare_text_for_static category.to_s %>"
-          slug: "<%= category.slug %>"
+      - name: "<%= prepare_text_for_static category.to_s %>"
+        slug: "<%= category.slug %>"
 <% end %>
-<% end %>
-  without_facets:
-<% 
-about_categories.each do |category| 
-  next if category.in_facet?
-%>
-    - name: "<%= prepare_text_for_static category.to_s %>"
-      slug: "<%= category.slug %>"
 <% end %>
 <% end %>

--- a/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
+++ b/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
@@ -15,7 +15,7 @@
         <%= render  "admin/application/slug/form",
                     f: f,
                     source: '#communication_website_portfolio_category_name' %>
-        <%= f.input :is_facet, label: t('admin.categories.is_facet') if category.possible_facet? %>
+        <%= f.input :is_taxonomy, label: t('admin.categories.is_taxonomy') if category.possible_taxonomy? %>
       <% end %>
       <%= render 'admin/application/featured_image/edit', about: category, f: f %>
     </div>

--- a/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
+++ b/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
@@ -15,7 +15,7 @@
         <%= render  "admin/application/slug/form",
                     f: f,
                     source: '#communication_website_portfolio_category_name' %>
-        <%= f.input :facet, label: t('admin.categories.facet') if category.possible_facet? %>
+        <%= f.input :is_facet, label: t('admin.categories.facet') if category.possible_facet? %>
       <% end %>
       <%= render 'admin/application/featured_image/edit', about: category, f: f %>
     </div>

--- a/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
+++ b/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
@@ -15,7 +15,7 @@
         <%= render  "admin/application/slug/form",
                     f: f,
                     source: '#communication_website_portfolio_category_name' %>
-        <%= f.input :is_facet, label: t('admin.categories.facet') if category.possible_facet? %>
+        <%= f.input :is_facet, label: t('admin.categories.is_facet') if category.possible_facet? %>
       <% end %>
       <%= render 'admin/application/featured_image/edit', about: category, f: f %>
     </div>

--- a/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
+++ b/app/views/admin/communication/websites/portfolio/categories/_form.html.erb
@@ -15,6 +15,7 @@
         <%= render  "admin/application/slug/form",
                     f: f,
                     source: '#communication_website_portfolio_category_name' %>
+        <%= f.input :facet, label: t('admin.categories.facet') if category.possible_facet? %>
       <% end %>
       <%= render 'admin/application/featured_image/edit', about: category, f: f %>
     </div>

--- a/app/views/admin/communication/websites/portfolio/projects/_form.html.erb
+++ b/app/views/admin/communication/websites/portfolio/projects/_form.html.erb
@@ -8,17 +8,8 @@
         <%= f.input :title %>
         <%= render 'admin/application/summary/form', f: f, about: project %>
       <% end %>
-      <% if @categories.any? %>
-        <%= osuny_panel t('activerecord.attributes.communication/website/portfolio/project.categories') do %>
-          <%= f.association :categories,
-                            label_text: false,
-                            as: :check_boxes,
-                            collection: collection_tree_for_checkboxes(@categories) %>
-        <% end %>
-      <% end %>
-
+      <%= render 'admin/application/categories/form', f: f, categories: @categories %>
       <%= render 'admin/application/meta_description/form', f: f, about: project %>
-
     </div>
     <div class="col-md-4">
       <%= osuny_panel t('metadata') do %>

--- a/app/views/admin/communication/websites/portfolio/projects/static.html.erb
+++ b/app/views/admin/communication/websites/portfolio/projects/static.html.erb
@@ -10,11 +10,9 @@
 <%= render 'admin/application/summary/static' %>
 year: <%= @about.year %>
 date: <%= @about.year %>
-<% if @about.categories.any? %>
-projects_categories:
-<% @about.categories.ordered.each do |category| %>
-  - "<%= category.slug %>"
-<% end %>
-<% end %>
+<%= render 'admin/application/categories/static', 
+            about: @about, 
+            categories: Communication::Website::Portfolio::Category,
+            key: :project_categories %>
 <%= render 'admin/communication/blocks/content/static', about: @about %>
 ---

--- a/app/views/admin/communication/websites/portfolio/projects/static.html.erb
+++ b/app/views/admin/communication/websites/portfolio/projects/static.html.erb
@@ -13,6 +13,6 @@ date: <%= @about.year %>
 <%= render 'admin/application/categories/static', 
             about: @about, 
             categories_model: Communication::Website::Portfolio::Category,
-            key: :project_categories %>
+            key: :projects_categories %>
 <%= render 'admin/communication/blocks/content/static', about: @about %>
 ---

--- a/app/views/admin/communication/websites/portfolio/projects/static.html.erb
+++ b/app/views/admin/communication/websites/portfolio/projects/static.html.erb
@@ -12,7 +12,7 @@ year: <%= @about.year %>
 date: <%= @about.year %>
 <%= render 'admin/application/categories/static', 
             about: @about, 
-            categories: Communication::Website::Portfolio::Category,
+            categories_model: Communication::Website::Portfolio::Category,
             key: :project_categories %>
 <%= render 'admin/communication/blocks/content/static', about: @about %>
 ---

--- a/app/views/admin/communication/websites/portfolio/projects/static.html.erb
+++ b/app/views/admin/communication/websites/portfolio/projects/static.html.erb
@@ -12,7 +12,7 @@ year: <%= @about.year %>
 date: <%= @about.year %>
 <%= render 'admin/application/categories/static', 
             about: @about, 
-            categories_model: Communication::Website::Portfolio::Category,
+            categories: @website.portfolio_categories,
             key: :projects_categories %>
 <%= render 'admin/communication/blocks/content/static', about: @about %>
 ---

--- a/config/locales/communication/en.yml
+++ b/config/locales/communication/en.yml
@@ -313,7 +313,7 @@ en:
         other: Tags
   admin:
     categories:
-      is_facet: Is a facet (a kind of categories)
+      is_facet: Is a taxonomy (a family of categories)
       other: Other
       title: Categories
     communication:

--- a/config/locales/communication/en.yml
+++ b/config/locales/communication/en.yml
@@ -313,7 +313,7 @@ en:
         other: Tags
   admin:
     categories:
-      facet: Is a facet (a kind of categories)
+      is_facet: Is a facet (a kind of categories)
       other: Other
       title: Categories
     communication:

--- a/config/locales/communication/en.yml
+++ b/config/locales/communication/en.yml
@@ -312,6 +312,10 @@ en:
         one: Tag
         other: Tags
   admin:
+    categories:
+      facet: Is a facet (a kind of categories)
+      other: Other
+      title: Categories
     communication:
       block:
         copied: The block has been copied to clipboard!

--- a/config/locales/communication/en.yml
+++ b/config/locales/communication/en.yml
@@ -313,7 +313,7 @@ en:
         other: Tags
   admin:
     categories:
-      is_facet: Is a taxonomy (a family of categories)
+      is_taxonomy: Is a taxonomy (a family of categories)
       other: Other
       title: Categories
     communication:

--- a/config/locales/communication/fr.yml
+++ b/config/locales/communication/fr.yml
@@ -313,7 +313,7 @@ fr:
         other: Mot-clés
   admin:
     categories:
-      facet: Est une facette (un type de catégories)
+      is_facet: Est une facette (un type de catégories)
       other: Autres
       title: Catégories
     communication:

--- a/config/locales/communication/fr.yml
+++ b/config/locales/communication/fr.yml
@@ -312,6 +312,10 @@ fr:
         one: Mot-clé
         other: Mot-clés
   admin:
+    categories:
+      facet: Est une facette (un type de catégories)
+      other: Autres
+      title: Catégories
     communication:
       block:
         copied: Le bloc a bien été copié dans le presse-papier.

--- a/config/locales/communication/fr.yml
+++ b/config/locales/communication/fr.yml
@@ -313,7 +313,7 @@ fr:
         other: Mot-clés
   admin:
     categories:
-      is_facet: Est une taxonomie (une famille de catégories)
+      is_taxonomy: Est une taxonomie (une famille de catégories)
       other: Autres
       title: Catégories
     communication:

--- a/config/locales/communication/fr.yml
+++ b/config/locales/communication/fr.yml
@@ -313,7 +313,7 @@ fr:
         other: Mot-clés
   admin:
     categories:
-      is_facet: Est une facette (un type de catégories)
+      is_facet: Est une taxonomie (une famille de catégories)
       other: Autres
       title: Catégories
     communication:

--- a/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
+++ b/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
@@ -1,0 +1,5 @@
+class AddFacetToCommunicationWebsitePortfolioCategory < ActiveRecord::Migration[7.1]
+  def change
+    add_column :communication_website_portfolio_categories, :facet, :boolean, default: false
+  end
+end

--- a/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
+++ b/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
@@ -1,5 +1,5 @@
 class AddFacetToCommunicationWebsitePortfolioCategory < ActiveRecord::Migration[7.1]
   def change
-    add_column :communication_website_portfolio_categories, :is_facet, :boolean, default: false
+    add_column :communication_website_portfolio_categories, :is_taxonomy, :boolean, default: false
   end
 end

--- a/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
+++ b/db/migrate/20240730080436_add_facet_to_communication_website_portfolio_category.rb
@@ -1,5 +1,5 @@
 class AddFacetToCommunicationWebsitePortfolioCategory < ActiveRecord::Migration[7.1]
   def change
-    add_column :communication_website_portfolio_categories, :facet, :boolean, default: false
+    add_column :communication_website_portfolio_categories, :is_facet, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_05_160162) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_30_080436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -151,6 +151,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_160162) do
     t.uuid "heading_id"
     t.uuid "communication_website_id"
     t.string "migration_identifier"
+    t.string "html_class"
     t.index ["about_type", "about_id"], name: "index_communication_website_blocks_on_about"
     t.index ["communication_website_id"], name: "index_communication_blocks_on_communication_website_id"
     t.index ["heading_id"], name: "index_communication_blocks_on_heading_id"
@@ -520,6 +521,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_160162) do
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_facet", default: false
     t.index ["communication_website_id"], name: "idx_on_communication_website_id_8f309901d4"
     t.index ["language_id"], name: "idx_on_language_id_6e6ffc92a8"
     t.index ["original_id"], name: "idx_on_original_id_4cbc9f1290"


### PR DESCRIPTION
Les catégories racines peuvent devenir des facettes.
L'idée est de tester ça sur les projets pour le site de Takumi, puis de généraliser à toutes les catégories.

## Admin

Dans l'objet que l'on catégorise, on a alors cette interface :

<img width="1117" alt="Capture d’écran 2024-07-30 à 10 29 06" src="https://github.com/user-attachments/assets/171545cf-8c7f-4f19-83e5-0c1a21e52733">

Attention, il n'y a pas de gestion des arbres dans les facettes, il faudra la refaire quand https://github.com/osunyorg/admin/pull/2025 sera faite. 

## Static

```yaml
project_categories:
  - "mode"
  - "design"
  - "et-accessible"
  - "gratuit"
taxonomies:
  - name: "Secteur"
    slug: "secteur"
    categories:
      - name: "Mode"
        permalink: ""
        file: "content/fr/projects_categories/mode/_index.html"
        path: "/mode/"
        slug: "mode"
  - name: "Expertise"
    slug: "expertise"
    categories:
      - name: "Design"
        permalink: ""
        file: "content/fr/projects_categories/design/_index.html"
        path: "/design/"
        slug: "design"
```