### PR TITLE
Correction Task HAL + Connexion après importation

### DIFF
--- a/app/models/research/hal.rb
+++ b/app/models/research/hal.rb
@@ -12,6 +12,9 @@ module Research::Hal
       Research::Hal::Author.find_each do |author|
         author.import_research_hal_publications!
       end
+      University::Person.joins(:research_hal_authors).distinct.find_each do |person|
+        person.connect_research_hal_publications!
+      end
     ensure
       unpause_git_sync
     end

--- a/app/models/university/person/with_research.rb
+++ b/app/models/university/person/with_research.rb
@@ -33,11 +33,21 @@ module University::Person::WithResearch
     scope :with_hal_identifier, -> { where.not(hal_form_identifier: [nil,'']) }
   end
 
+  # Import HAL publications by retrieving them from API
   def import_research_hal_publications!
     publications.delete(publications.hal)
     hal_authors.each do |author|
       # TODO manage same researcher in different universities
       publications.concat author.import_research_hal_publications!
+    end
+  end
+
+  # Connect HAL publications from HAL authors without calling the API
+  def connect_research_hal_publications!
+    publications.delete(publications.hal)
+    hal_authors.each do |author|
+      # TODO manage same researcher in different universities
+      publications.concat author.publications
     end
   end
 

--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "0 1 * * * rails auto:update_publications_from_hal",
+      "command": "0 1 * * * rails auto:update_hal",
       "size": "L"
     },
     {


### PR DESCRIPTION
La task n'avait pas le bon nom. Ensuite, on importait les publications des auteurs HAL mais la connexion aux chercheurs liés à ces auteurs n'était pas mise à jour. J'ai "dupliqué" la méthode `import_research_hal_publications!` en ajustant pour ne pas rappeler l'API mais simplement en connectant aux publications des auteurs