### PR TITLE
Program > Portfolio category + related categories

### DIFF
--- a/app/models/communication/website/agenda/category.rb
+++ b/app/models/communication/website/agenda/category.rb
@@ -4,6 +4,7 @@
 #
 #  id                       :uuid             not null, primary key
 #  is_programs_root         :boolean          default(FALSE)
+#  is_taxonomy              :boolean          default(FALSE)
 #  position                 :integer
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/app/models/communication/website/post/category.rb
+++ b/app/models/communication/website/post/category.rb
@@ -4,6 +4,7 @@
 #
 #  id                       :uuid             not null, primary key
 #  is_programs_root         :boolean          default(FALSE)
+#  is_taxonomy              :boolean          default(FALSE)
 #  position                 :integer
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/app/models/communication/website/with_program_categories.rb
+++ b/app/models/communication/website/with_program_categories.rb
@@ -10,7 +10,7 @@ module Communication::Website::WithProgramCategories
   end
 
   def set_programs_categories_safely
-    [post_categories, agenda_categories].each do |objects|
+    [post_categories, agenda_categories, portfolio_categories].each do |objects|
       programs_root_category = set_programs_categories_root_for!(objects)
       set_programs_categories_at_level_for! objects, programs_root_category, education_programs.root.ordered
     end

--- a/app/models/education/program/with_websites_categories.rb
+++ b/app/models/education/program/with_websites_categories.rb
@@ -4,18 +4,28 @@ module Education::Program::WithWebsitesCategories
   included do
     after_save_commit :set_websites_categories
 
-    has_many   :website_post_categories,
-               class_name: 'Communication::Website::Post::Category',
-               dependent: :destroy
-
     has_many   :website_agenda_categories,
                class_name: 'Communication::Website::Agenda::Category',
                dependent: :destroy
 
-    # TODO : Ajouter les catégories de portfolio
+    has_many   :website_portfolio_categories,
+               class_name: 'Communication::Website::Portfolio::Category',
+               dependent: :destroy
+
+    has_many   :website_post_categories,
+               class_name: 'Communication::Website::Post::Category',
+               dependent: :destroy
   end
 
   def set_websites_categories
     websites.each { |website| website.set_programs_categories }
+  end
+
+  def website_category_l10ns_for(website, language)
+    categories = {}
+    categories[:agenda] = website_agenda_categories.find_by(communication_website_id: website.id)&.localization_for(language)
+    categories[:blog] = website_post_categories.find_by(communication_website_id: website.id)&.localization_for(language)
+    categories[:portfolio] = website_portfolio_categories.find_by(communication_website_id: website.id)&.localization_for(language)
+    categories.compact
   end
 end

--- a/app/views/admin/education/programs/static.html.erb
+++ b/app/views/admin/education/programs/static.html.erb
@@ -51,11 +51,17 @@ logo:
 <% end %>
 <%
 if @website
-  post_category = @website.post_categories.find_by(program_id: program.id)
-  post_category_l10n = post_category&.localization_for(language)
-  if post_category_l10n
+  website_category_l10ns = program.website_category_l10ns_for(@website, language)
+  if website_category_l10ns[:blog]
 %>
-related_category: "<%= post_category_l10n.slug_with_ancestors_slugs(separator: '-') %>"
+<%# related_category is deprecated, in favor of related_categories %>
+related_category: "<%= website_category_l10ns[:blog].slug_with_ancestors_slugs(separator: '-') %>"
+<%
+  end
+%>
+related_categories:
+<% website_category_l10ns.each do |key, website_category_l10n| %>
+  <%= key %>: "<%= website_category_l10n.slug_with_ancestors_slugs(separator: '-') %>"
 <%
   end
 end

--- a/db/migrate/20241017081524_add_is_taxonomy_to_other_website_categories.rb
+++ b/db/migrate/20241017081524_add_is_taxonomy_to_other_website_categories.rb
@@ -1,0 +1,6 @@
+class AddIsTaxonomyToOtherWebsiteCategories < ActiveRecord::Migration[7.1]
+  def change
+    add_column :communication_website_agenda_categories, :is_taxonomy, :boolean, default: false
+    add_column :communication_website_post_categories, :is_taxonomy, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_17_081524) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "unaccent"
 
-  create_table "action_text_rich_texts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "action_text_rich_texts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
     t.string "record_type", null: false
@@ -27,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
-  create_table "active_storage_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.uuid "record_id", null: false
@@ -37,7 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -51,7 +52,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_active_storage_blobs_on_university_id"
   end
 
-  create_table "active_storage_variant_records", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -105,7 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["education_school_id", "administration_location_id"], name: "index_location_school"
   end
 
-  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "number"
     t.text "name"
     t.text "description"
@@ -113,7 +114,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "criterion_id", null: false
     t.integer "number"
     t.text "name"
@@ -127,7 +128,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["criterion_id"], name: "index_administration_qualiopi_indicators_on_criterion_id"
   end
 
-  create_table "communication_block_headings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_block_headings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "about_type", null: false
     t.uuid "about_id", null: false
@@ -145,7 +146,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_block_headings_on_university_id"
   end
 
-  create_table "communication_blocks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "about_type"
     t.uuid "about_id"
@@ -166,7 +167,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_blocks_on_university_id"
   end
 
-  create_table "communication_extranet_connections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_connections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "extranet_id", null: false
     t.string "about_type"
@@ -178,7 +179,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_extranet_connections_on_university_id"
   end
 
-  create_table "communication_extranet_document_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_document_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
@@ -217,7 +218,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_0dc1259072"
   end
 
-  create_table "communication_extranet_document_kinds", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_document_kinds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
@@ -242,7 +243,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_95419f1df4"
   end
 
-  create_table "communication_extranet_documents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "extranet_id", null: false
     t.datetime "created_at", null: false
@@ -275,7 +276,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_extranet_localizations_on_university_id"
   end
 
-  create_table "communication_extranet_post_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
@@ -320,7 +321,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_28188e2217"
   end
 
-  create_table "communication_extranet_posts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "author_id"
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
@@ -333,7 +334,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_extranet_posts_on_university_id"
   end
 
-  create_table "communication_extranets", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "host"
     t.datetime "created_at", null: false
@@ -369,6 +370,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.uuid "parent_id"
     t.boolean "is_programs_root", default: false
     t.uuid "program_id"
+    t.boolean "is_taxonomy", default: false
     t.index ["communication_website_id"], name: "idx_communication_website_agenda_cats_on_website_id"
     t.index ["parent_id"], name: "index_communication_website_agenda_categories_on_parent_id"
     t.index ["program_id"], name: "index_communication_website_agenda_categories_on_program_id"
@@ -421,7 +423,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_eaf79b0514"
   end
 
-  create_table "communication_website_agenda_events", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_agenda_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.date "from_day"
@@ -454,7 +456,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["communication_website_post_id", "communication_website_category_id"], name: "post_category"
   end
 
-  create_table "communication_website_connections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_connections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "website_id", null: false
     t.string "indirect_object_type", null: false
@@ -489,7 +491,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_website_git_file_orphans_on_university_id"
   end
 
-  create_table "communication_website_git_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_git_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "previous_path"
     t.string "about_type", null: false
     t.uuid "about_id", null: false
@@ -526,7 +528,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_website_localizations_on_university_id"
   end
 
-  create_table "communication_website_menu_items", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menu_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "website_id", null: false
     t.uuid "menu_id", null: false
@@ -546,7 +548,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["website_id"], name: "index_communication_website_menu_items_on_website_id"
   end
 
-  create_table "communication_website_menus", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menus", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.string "title"
@@ -590,7 +592,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_e62b2aba53"
   end
 
-  create_table "communication_website_pages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.text "path"
@@ -608,7 +610,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_communication_website_pages_on_university_id"
   end
 
-  create_table "communication_website_permalinks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_permalinks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "website_id", null: false
     t.string "about_type", null: false
@@ -699,7 +701,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_ac2f4a0bfc"
   end
 
-  create_table "communication_website_post_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.integer "position"
@@ -708,6 +710,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.uuid "parent_id"
     t.uuid "program_id"
     t.boolean "is_programs_root", default: false
+    t.boolean "is_taxonomy", default: false
     t.index ["communication_website_id"], name: "idx_communication_website_post_cats_on_communication_website_id"
     t.index ["parent_id"], name: "index_communication_website_post_categories_on_parent_id"
     t.index ["program_id"], name: "index_communication_website_post_categories_on_program_id"
@@ -758,7 +761,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_a3a3f1e954"
   end
 
-  create_table "communication_website_posts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -784,7 +787,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["communication_website_showcase_tag_id", "communication_website_id"], name: "index_showcase_tag_website"
   end
 
-  create_table "communication_websites", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_websites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "url"
     t.datetime "created_at", null: false
@@ -852,7 +855,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "education_academic_years", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_academic_years", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.integer "year"
     t.datetime "created_at", null: false
@@ -867,7 +870,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_person_id", "education_academic_year_id"], name: "index_person_academic_year"
   end
 
-  create_table "education_cohorts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "program_id", null: false
     t.uuid "academic_year_id", null: false
@@ -906,7 +909,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_education_diploma_localizations_on_university_id"
   end
 
-  create_table "education_diplomas", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_diplomas", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "level", default: 0
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
@@ -989,7 +992,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_education_program_localizations_on_university_id"
   end
 
-  create_table "education_programs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_programs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.integer "capacity"
     t.boolean "continuing"
@@ -1043,7 +1046,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_education_school_localizations_on_university_id"
   end
 
-  create_table "education_schools", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "address"
     t.string "zipcode"
@@ -1057,7 +1060,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_education_schools_on_university_id"
   end
 
-  create_table "emergency_messages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "emergency_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id"
     t.string "name"
     t.string "role"
@@ -1160,7 +1163,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
-  create_table "imports", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "number_of_lines"
     t.jsonb "processing_errors"
     t.integer "kind"
@@ -1175,7 +1178,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 
-  create_table "languages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "languages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "iso_code"
     t.datetime "created_at", null: false
@@ -1189,7 +1192,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id", "language_id"], name: "index_languages_universities_on_university_id_and_language_id"
   end
 
-  create_table "research_hal_authors", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_hal_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "docid"
     t.string "form_identifier"
     t.string "person_identifier"
@@ -1243,7 +1246,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_dc9f1267b7"
   end
 
-  create_table "research_journal_paper_kinds", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_paper_kinds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "journal_id", null: false
     t.datetime "created_at", null: false
@@ -1272,7 +1275,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_research_journal_paper_localizations_on_university_id"
   end
 
-  create_table "research_journal_papers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_papers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_journal_id", null: false
     t.uuid "research_journal_volume_id"
@@ -1321,7 +1324,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_research_journal_volume_localizations_on_university_id"
   end
 
-  create_table "research_journal_volumes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_volumes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_journal_id", null: false
     t.integer "number"
@@ -1331,14 +1334,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_research_journal_volumes_on_university_id"
   end
 
-  create_table "research_journals", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["university_id"], name: "index_research_journals_on_university_id"
   end
 
-  create_table "research_laboratories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "address"
     t.string "zipcode"
@@ -1356,7 +1359,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_person_id", "research_laboratory_id"], name: "laboratory_person"
   end
 
-  create_table "research_laboratory_axes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratory_axes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_laboratory_id", null: false
     t.integer "position"
@@ -1395,7 +1398,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_research_laboratory_localizations_on_university_id"
   end
 
-  create_table "research_publications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_publications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "hal_docid"
     t.jsonb "data"
     t.string "title"
@@ -1426,7 +1429,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_person_id", "research_publication_id"], name: "index_publication_person"
   end
 
-  create_table "research_theses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_theses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_laboratory_id", null: false
     t.uuid "author_id", null: false
@@ -1455,7 +1458,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_research_thesis_localizations_on_university_id"
   end
 
-  create_table "universities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "universities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "identifier"
     t.string "address"
@@ -1484,7 +1487,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["name"], name: "index_universities_on_name", opclass: :gin_trgm_ops, using: :gin
   end
 
-  create_table "university_apps", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_apps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "university_id", null: false
     t.string "token"
@@ -1495,7 +1498,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_university_apps_on_university_id"
   end
 
-  create_table "university_organization_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organization_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1542,7 +1545,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_university_organization_localizations_on_university_id"
   end
 
-  create_table "university_organizations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "address"
     t.string "zipcode"
@@ -1563,14 +1566,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_university_organizations_on_university_id"
   end
 
-  create_table "university_organizations_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organizations_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "category_id", null: false
     t.index ["category_id"], name: "index_university_organizations_categories_on_category_id"
     t.index ["organization_id"], name: "index_university_organizations_categories_on_organization_id"
   end
 
-  create_table "university_people", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "user_id"
     t.boolean "is_researcher"
@@ -1604,14 +1607,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["user_id"], name: "index_university_people_on_user_id"
   end
 
-  create_table "university_people_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_people_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "person_id", null: false
     t.uuid "category_id", null: false
     t.index ["category_id"], name: "index_university_people_categories_on_category_id"
     t.index ["person_id"], name: "index_university_people_categories_on_person_id"
   end
 
-  create_table "university_person_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1647,7 +1650,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_1be9c668d5"
   end
 
-  create_table "university_person_experiences", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_experiences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "person_id", null: false
     t.uuid "organization_id", null: false
@@ -1672,7 +1675,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "idx_on_university_id_0b815cf13a"
   end
 
-  create_table "university_person_involvements", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_involvements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "person_id", null: false
     t.integer "kind"
@@ -1722,7 +1725,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_university_role_localizations_on_university_id"
   end
 
-  create_table "university_roles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "target_type"
     t.uuid "target_id"
@@ -1733,7 +1736,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["university_id"], name: "index_university_roles_on_university_id"
   end
 
-  create_table "user_favorites", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "user_favorites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "about_type", null: false
     t.uuid "about_id", null: false
@@ -1743,7 +1746,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_094257) do
     t.index ["user_id"], name: "index_user_favorites_on_user_id"
   end
 
-  create_table "users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "first_name"
     t.string "last_name"


### PR DESCRIPTION
- Ajout des catégories de portfolio liés aux formations
- Dans le static des formations, ajout d'une clé `related_categories` pour gérer les autres namespaces, en dépréciant l'ancienne clé unique `related_category`
- WIP is_taxonomy sur les autres catégories