### PR TITLE
Formations ordonnées par slug

### DIFF
--- a/app/models/concerns/localizable_order_by_slug_scope.rb
+++ b/app/models/concerns/localizable_order_by_slug_scope.rb
@@ -1,0 +1,29 @@
+module LocalizableOrderBySlugScope
+  extend ActiveSupport::Concern
+
+  # Cf LocalizableOrderByNameScope
+  included do
+    scope :ordered, -> (language) {
+      localization_name_select = <<-SQL
+        COALESCE(
+          MAX(CASE WHEN localizations.language_id = '#{language.id}' THEN TRIM(LOWER(UNACCENT(localizations.slug))) END),
+          MAX(TRIM(LOWER(UNACCENT(localizations.slug)))) FILTER (WHERE localizations.rank = 1)
+        ) AS localization_slug
+      SQL
+
+      joins(sanitize_sql_array([<<-SQL
+        LEFT JOIN (
+          SELECT
+            localizations.*,
+            ROW_NUMBER() OVER(PARTITION BY localizations.about_id ORDER BY localizations.created_at ASC) as rank
+          FROM
+            #{table_name.singularize}_localizations as localizations
+        ) localizations ON #{table_name}.id = localizations.about_id
+      SQL
+      ]))
+      .select("#{table_name}.*", localization_name_select)
+      .group("#{table_name}.id")
+      .order("localization_slug ASC")
+    }
+  end
+end

--- a/app/models/education/program.rb
+++ b/app/models/education/program.rb
@@ -30,7 +30,7 @@ class Education::Program < ApplicationRecord
   include AsIndirectObject
   include Filterable
   include Localizable
-  include LocalizableOrderByNameScope
+  include LocalizableOrderBySlugScope
   include Sanitizable
   include WebsitesLinkable
   include WithAlumni


### PR DESCRIPTION
Cela permet de créer des ordres subtils.
Par défaut, c'est identique à l'ordre alphabétique de nom, mais si on veut on peut faire autrement (comme pour mettre en ordre les formations enfants du conservatoire)