### PR TITLE
AsLocalizedTree: use about_class.ordered instead of using arbitrary position

### DIFF
--- a/app/models/concerns/as_localized_tree.rb
+++ b/app/models/concerns/as_localized_tree.rb
@@ -6,7 +6,9 @@ module AsLocalizedTree
       joins(:about).where(about_table_name => { parent_id: nil })
     }
     scope :ordered, -> (language = nil) {
-      joins(:about).order("#{about_table_name}.position")
+      # Use the ordered scope from the about class
+      joins(:about)
+        .merge(about_class.ordered(language))
     }
   end
 

--- a/app/models/education/program/localization.rb
+++ b/app/models/education/program/localization.rb
@@ -53,7 +53,7 @@
 #
 class Education::Program::Localization < ApplicationRecord
   include AsLocalization
-  include AsLocalizedTree
+  include AsLocalizedTree # ordered scope is overridden below
   include Contentful
   include Initials
   include Pathable
@@ -91,6 +91,8 @@ class Education::Program::Localization < ApplicationRecord
   validates :name, presence: true
   validates :downloadable_summary, size: { less_than: 50.megabytes }
   validates :logo, size: { less_than: 5.megabytes }
+
+  scope :ordered, -> (language = nil) { order(:slug) }
 
   def git_path(website)
     return unless published? && for_website?(website)


### PR DESCRIPTION
Que ça soit pour les formations ou même pour les évènements, rien ne dit qu'une classe de localisation avec `AsLocalizedTree` a un about_class ayant `Orderable`. On délègue donc simplement le ordered à l'about.

Cependant pour les localisations de formations, il faut quand même override car cela ne dépend pas de l'about mais du slug de la L10N elle-même