### PR TITLE
Correction de la génération de page diplômes sur un site de formation

### DIFF
--- a/app/models/education/program/with_diploma.rb
+++ b/app/models/education/program/with_diploma.rb
@@ -5,6 +5,9 @@ module Education::Program::WithDiploma
     belongs_to  :diploma,
                 class_name: 'Education::Diploma',
                 optional: true
+
+    alias :education_diploma :diploma
+    alias :education_diplomas :diplomas
   end
 
   # Used by website


### PR DESCRIPTION
Fix #2850 

Pour répondre correctement à `Communication::Website::Page::EducationDiploma#is_necessary_for_website?`

https://github.com/osunyorg/admin/blob/ecffcbaa9be153e8169a9d9823088751bc4a1c84/app/models/communication/website/page/education_diploma.rb#L4