### PR TITLE
Le menu social n'est plus généré automatiquement

### DIFF
--- a/app/models/communication/website/menu.rb
+++ b/app/models/communication/website/menu.rb
@@ -29,7 +29,7 @@
 #
 class Communication::Website::Menu < ApplicationRecord
   IDENTIFIER_MAX_LENGTH = 100
-  DEFAULT_MENUS_IDENTIFIERS = ['primary', 'legal', 'social'].freeze
+  DEFAULT_MENUS_IDENTIFIERS = ['primary', 'legal'].freeze
 
   include AsDirectObject
   include Initials


### PR DESCRIPTION
Fix #1668

Il y a les infos de contact des sites maintenant.