### PR TITLE
Correction de dépendances/références des écoles et formations avec les campus

### DIFF
--- a/app/models/administration/location.rb
+++ b/app/models/administration/location.rb
@@ -53,7 +53,10 @@ class Administration::Location < ApplicationRecord
 
   def dependencies
     localizations +
-    programs +
+    programs
+  end
+
+  def references
     schools
   end
 

--- a/app/models/education/program.rb
+++ b/app/models/education/program.rb
@@ -83,7 +83,6 @@ class Education::Program < ApplicationRecord
   def dependencies
     localizations +
     categories +
-    locations +
     university_people_through_involvements.map(&:teacher_facets) +
     university_people_through_role_involvements.map(&:administrator_facets) +
     [diploma]
@@ -92,6 +91,7 @@ class Education::Program < ApplicationRecord
   def references
     super +
     schools +
+    locations +
     siblings +
     descendants +
     [parent]


### PR DESCRIPTION
Effet de bord lors d'un site de formation : l'école et des formations se retrouvent connectées via les campus de la formation

Il paraîtrait logique que les campus ne soient pas des dépendances mais des références de la formation.

De même, les écoles ne sont pas des dépendances du campus, mais des références