### PR TITLE
Bloc organisations : ajout de la mise en page "Large"

### DIFF
--- a/app/models/communication/block/template/organization.rb
+++ b/app/models/communication/block/template/organization.rb
@@ -1,7 +1,11 @@
 class Communication::Block::Template::Organization < Communication::Block::Template::Base
 
   has_elements
-  has_layouts [:grid, :map]
+  has_layouts [
+    :grid,
+    :large,
+    :map
+  ]
   has_component :mode, :option, options: [
     :selection,
     :category

--- a/config/locales/communication/blocks/en.yml
+++ b/config/locales/communication/blocks/en.yml
@@ -478,6 +478,9 @@ en:
               grid:
                 description: Square logos and a simple text below.
                 label: Grid
+              large:
+                description: Each organization is presented in majesty, across the full width available, with a large image.
+                label: Grand
               map:
                 description: A geographic map, with a pin for every organization with a known location.
                 label: Map

--- a/config/locales/communication/blocks/fr.yml
+++ b/config/locales/communication/blocks/fr.yml
@@ -478,6 +478,9 @@ fr:
               grid:
                 description: Une série de logos carrés, avec le nom de chaque organisation.
                 label: Grille
+              large:
+                description: Chaque organisation est présentée en majesté, sur toute la largeur disponible avec une grande image.
+                label: Grand
               map:
                 description: Une carte géographique avec un repère pour chaque organisation dont l'adresse est connue.
                 label: Carte


### PR DESCRIPTION
Ajout du format large pour les organisations

<img width="1839" alt="image" src="https://github.com/user-attachments/assets/b9ec0153-d172-4d44-95ca-b51c28e03dcf" />
