### PR TITLE
Limitation de la taille des prévisualisations

### DIFF
--- a/app/services/osuny/media/picker.rb
+++ b/app/services/osuny/media/picker.rb
@@ -65,7 +65,7 @@ class Osuny::Media::Picker
   end
 
   def url
-    @url ||= image.attached? ? "/media/#{image.signed_id}/preview.png" : ''
+    @url ||= image.attached? ? "/media/#{image.signed_id}/preview_800x.png" : ''
   end
 
   def about_type


### PR DESCRIPTION
Fix #3332

C'est une petite amélioration, qui utilise l'infrastructure existante pour limiter à 800 pixels de large les previews.
On pourrait clairement faire mieux (kamifusen, qualité...) mais il faut gérer finement les cas, notamment les svg.