### PR TITLE
Gestion des traductions trop longues

### DIFF
--- a/app/assets/javascripts/admin/commons/translation.js
+++ b/app/assets/javascripts/admin/commons/translation.js
@@ -57,7 +57,8 @@ window.osuny.translation = {
         }
     },
 
-    warnForTextTooLong: function(field) {
+    warnForTextTooLong: function (field) {
+        'use strict';
         var element = field;
         if (this.isSummernote(field)) {
             element = field.parentNode.getElementsByClassName('note-editable')[0];
@@ -76,7 +77,8 @@ window.osuny.translation = {
         }
     },
 
-    isSummernote: function(field) {
+    isSummernote: function (field) {
+        'use strict';
         return field.dataset.provider === 'summernote' || field.classList.contains('summernote-vue');
     },
 


### PR DESCRIPTION
Fix #3659

Cela évitera de faire des requêtes qui ne peuvent pas marcher, et cela donne un petit feedback (cadre rouge) pas encore très clair.

<img width="839" height="293" alt="Capture d’écran 2025-12-31 à 08 48 25" src="https://github.com/user-attachments/assets/3f02720d-bb08-49bc-b98d-be2d05e1f3e1" />
