### PR TITLE
Bloc CTA : indentation du crédit dans le static

### DIFF
--- a/app/views/admin/communication/blocks/templates/call_to_action/_static.html.erb
+++ b/app/views/admin/communication/blocks/templates/call_to_action/_static.html.erb
@@ -2,8 +2,8 @@
 <%= block_component_static block, :text %>
 <%= block_component_static block, :image %>
 <% if block.template.image_component.blob %>
-  <%= block_component_static block, :alt, depth: 4 %>
-  <%= block_component_static block, :credit, depth: 4 %>
+<%= block_component_static block, :alt, depth: 4 %>
+<%= block_component_static block, :credit, depth: 4 %>
 <% end %>
       buttons:
 <%


### PR DESCRIPTION
Le bloc CTA n'est pas aligné sur le format de static attendu dans le thème (comme pour les chapitres, cf PR https://github.com/osunyorg/admin/pull/3534)
De fait, aucun crédit n'apparaît : https://example.osuny.org/fr/blocks/blocks-narratifs/appels-a-action/

```
  - kind: block
    template: call_to_action
    ...
    data:
      layout: accent_background
      ...   
      image:
        id: "7ea3e92d-94ee-4595-abf3-fca575b1a4c5"
        file: "7ea3e92d-94ee-4595-abf3-fca575b1a4c5"

      alt: >-
        CTA simple texte

      credit: >-
        <p><a href="https://www.instagram.com/daniellfaro/" target="_blank" rel="noreferrer">Daniel Faro <span class="sr-only">(lien externe)</span></a>, Death to the Stock</p>
```

J'ai repris le bloc chapitre pour ajouter la nouvelle indentation : 

```
  - kind: block
    template: call_to_action
    ...
    data:
      layout: accent_background
      ...   
      image:
        id: "7ea3e92d-94ee-4595-abf3-fca575b1a4c5"
        file: "7ea3e92d-94ee-4595-abf3-fca575b1a4c5"
        alt: >-
        CTA simple texte
        credit: >-
          <p><a href="https://www.instagram.com/daniellfaro/" target="_blank" rel="noreferrer">Daniel Faro <span class="sr-only">(lien externe)</span></a>, Death to the Stock</p>

      alt: >-
        CTA simple texte

      credit: >-
        <p><a href="https://www.instagram.com/daniellfaro/" target="_blank" rel="noreferrer">Daniel Faro <span class="sr-only">(lien externe)</span></a>, Death to the Stock</p>
```