### PR TITLE
Réparation de l'arborescence des titres

### DIFF
--- a/app/models/communication/block/with_heading_ranks.rb
+++ b/app/models/communication/block/with_heading_ranks.rb
@@ -63,6 +63,7 @@ module Communication::Block::WithHeadingRanks
     return if template_title?
     about.blocks
           .template_title # We are looking for title blocks
+          .published
           .where('position < ?', position) # Before this block
           .order(position: :desc)
           .limit(1)


### PR DESCRIPTION
Quand un bloc titre est en brouillon, il n'est pas correctement ignoré.