### PR TITLE
Amélioration de la robustesse du fil d'ariane

### DIFF
--- a/app/views/admin/application/static/_breadcrumbs.html.erb
+++ b/app/views/admin/application/static/_breadcrumbs.html.erb
@@ -18,7 +18,8 @@ localizations.each do |l10n|
   permalink = hugo.permalink
   last = l10n == localizations.last
 %>
-  - title: "<%= title %>"
+  - title: >-
+      <%= prepare_text_for_static(title) %>
 <% if !last || last_item.present? %>
     path: "<%= permalink %>"
 <% end %>


### PR DESCRIPTION
Avant
```yaml
breadcrumbs:
  - title: "IDN"
    path: "/"
  - title: "Organisations"
    path: "/organisations/"
  - title: "15/15\15 Magazine"
```

Le backslash est considéré comme une séquence d'échappement incorrecte

Après
```yaml
breadcrumbs:
  - title: >-
       IDN
    path: "/"
  - title: >-
      Organisations
    path: "/organisations/"
  - title: >-
      15/15\15 Magazine
```

