### PR TITLE
Détection plus fine de l'URL de partage YouTube

### DIFF
--- a/app/services/video/provider/youtube.rb
+++ b/app/services/video/provider/youtube.rb
@@ -53,8 +53,9 @@ class Video::Provider::Youtube < Video::Provider::Default
 
   protected
 
+  # We need to be careful not to match some YouTube URLs like "https://www.youtube.com/?watch=abc&feature=youtu.be"
   def share_url?
-    video_url.include?('youtu.be')
+    video_url.include?('//youtu.be')
   end
 
   def live_url?


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Quand on va sur YouTube par un lien de partage `https://youtu.be/abc`, on est redirigés vers `https://www.youtube.com/watch?v=abc&feature=youtu.be`. Or cette URL était détectée comme share_url alors qu'on est sur le pattern par défaut. On ajuste la méthode `share_url?` pour éviter ce cas

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
