### PR TITLE
Update Hugo version to 0.154.5 in Deuxfleurs workflow

### DIFF
--- a/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
+++ b/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
@@ -30,7 +30,7 @@ jobs:
     - name: Installation de Hugo
       uses: noesya/actions-hugo@release
       with:
-        hugo-version: '0.148.2'
+        hugo-version: '0.154.5'
         extended: true
         withdeploy: true
 


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Passage à Hugo 0.154.5 suite à la mise à jour de Garage côté Deuxfleurs pour permettre la compatibilité du GZIP dans les paramètres définis dans production/config.yaml

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
