### PR TITLE
Move jobs to cats queue

### DIFF
--- a/app/jobs/communication/website/delete_obsolete_connections_job.rb
+++ b/app/jobs/communication/website/delete_obsolete_connections_job.rb
@@ -1,5 +1,5 @@
 class Communication::Website::DeleteObsoleteConnectionsJob < Communication::Website::BaseJob
-  queue_as :mice
+  queue_as :cats
 
   def execute
     website.delete_obsolete_connections_safely

--- a/app/jobs/communication/website/indirect_object/connect_to_websites_job.rb
+++ b/app/jobs/communication/website/indirect_object/connect_to_websites_job.rb
@@ -1,7 +1,7 @@
 # Ce n'est pas un Job qui hérite de Communication::Website::BaseJob, 
 # il n'y a pas de besoin de lock ni de lien avec un site en particulier.
 class Communication::Website::IndirectObject::ConnectToWebsitesJob < ApplicationJob
-  queue_as :mice
+  queue_as :cats
 
   def perform(indirect_object)
     indirect_object.connect_to_websites_safely

--- a/app/jobs/dependencies/clean_websites_if_necessary_job.rb
+++ b/app/jobs/dependencies/clean_websites_if_necessary_job.rb
@@ -1,5 +1,5 @@
 class Dependencies::CleanWebsitesIfNecessaryJob < ApplicationJob
-  queue_as :mice
+  queue_as :cats
 
   def perform(object_with_dependencies)
     object_with_dependencies.clean_websites_if_necessary_safely


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On déplace les jobs suivants dans la queue des cats, car la queue mice est sous-dimensionnée pour ce qu'ils font :
- DeleteObsoleteConnectionsJob
- IndirectObject::ConnectToWebsitesJob
- CleanWebsitesIfNecessaryJob

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
