### PR TITLE
Liste des enfants d'une page au bon format

### DIFF
--- a/app/views/admin/communication/websites/pages/static.html.erb
+++ b/app/views/admin/communication/websites/pages/static.html.erb
@@ -24,6 +24,14 @@ weight: <%= page.position %>
 <% if @l10n.children.published.any? %>
 children:
 <%
+# children is deprecated, remove when theme 9.2.0 is deployed
+@l10n.children.published.ordered.each do |child|
+  next unless child.about&.is_listed_among_children?
+%>
+  - "<%= child.git_path_relative %>"
+<% end %>
+child_pages:
+<%
 @l10n.children.published.ordered.each do |child|
   next unless child.about&.is_listed_among_children?
   hugo = child.hugo(@website)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fix #3902

```yaml
children:
  - "jobs/_index.html"
  - "posts/_index.html"
  - "schools/_index.html"
  - "academic_years/_index.html"
child_pages:
  - permalink: "/offres-d-emploi/"
    path: "/jobs"
    slug: "offres-d-emploi"
    file: "content/fr/jobs/_index.html"
  - permalink: "/actualites/"
    path: "/posts"
    slug: "actualites"
    file: "content/fr/posts/_index.html"
  - permalink: "/ecoles/"
    path: "/schools"
    slug: "ecoles"
    file: "content/fr/schools/_index.html"
  - permalink: "/alumni/"
    path: "/academic_years"
    slug: "alumni"
    file: "content/fr/academic_years/_index.html"
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
