### PR TITLE
Fix dxfl redirects by adding index.html if trailing slash

### DIFF
--- a/app/views/admin/communication/websites/configs/deuxfleurs_config/static.html.erb
+++ b/app/views/admin/communication/websites/configs/deuxfleurs_config/static.html.erb
@@ -17,9 +17,11 @@ Cache-Control = "max-age=31536000, no-transform, public"
 <%
 permalinks = @website.permalinks.not_current.not_root.ordered
 permalinks.find_each do |permalink|
+  from_path = permalink.path.ends_with?('/')  ? "#{permalink.path}index.html"
+                                              : permalink.path
 %>
 [[redirects]]
-from = "<%= permalink.path %>"
+from = "<%= from_path %>"
 to = "<%= permalink.target %>"
 
 <% end %>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction des redirections dxfl en ajoutant `index.html` si l'alias a un trailing slash

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
