### PR TITLE
Réparation des champs rich text qui ne suivent pas lors du déplacement

### DIFF
--- a/app/views/admin/communication/blocks/templates/agenda/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/agenda/_edit.html.erb
@@ -39,7 +39,7 @@
           </div>
           <div>
             <a  class="btn btn-sm text-danger ms-3"
-                v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+                v-on:click="deleteElement(element)"
                 title="<%= t('delete') %>">
                 <i class="<%= Icon::DELETE %>"></i>
             </a>

--- a/app/views/admin/communication/blocks/templates/call_to_action/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/call_to_action/_edit.html.erb
@@ -44,7 +44,7 @@
     </div>
     <div class="text-end">
       <a  class="btn btn-sm text-danger"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)">
+          v-on:click="deleteElement(element)">
         <i class="<%= Icon::DELETE %>"></i>
       </a>
     </div>

--- a/app/views/admin/communication/blocks/templates/definitions/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/definitions/_edit.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<draggable :list="data.elements" handle=".dragHandle" class="mb-3">
+<draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()" class="mb-3">
   <div v-for="(element, index) in data.elements" class="d-flex draggable-item">
     <div>
       <a class="btn ps-0 pt-0 dragHandle">
@@ -23,7 +23,7 @@
     </div>
     <div>
       <a  class="btn btn-sm text-danger ms-3"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+          v-on:click="deleteElement(element)"
           title="<%= t '.remove_definition' %>">
           <i class="<%= Icon::DELETE %>"></i>
       </a>

--- a/app/views/admin/communication/blocks/templates/exhibitions/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/exhibitions/_edit.html.erb
@@ -33,7 +33,7 @@
           </div>
           <div>
             <a  class="btn btn-sm text-danger ms-3"
-                v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+                v-on:click="deleteElement(element)"
                 title="<%= t('delete') %>">
                 <i class="<%= Icon::DELETE %>"></i>
             </a>

--- a/app/views/admin/communication/blocks/templates/features/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/features/_edit.html.erb
@@ -1,17 +1,22 @@
 <%= block_component_edit block, :description, summernote_config: 'mini' %>
 
-<%= osuny_separator %>
+<%= block_component_add_element block, t('.add_element') %>
 
-<draggable  class="row g-3 mb-3"
-            :list="data.elements"
-            handle=".dragHandle">
-  <div v-for="(element, index) in data.elements" class=" col-6 col-md-4">
-    <div class="card draggable-item dragHandle m-0">
-      <div class="card-body">
-        <a>
-          <i class="<%= Icon::MOVE %> handle"></i>
-          {{ element.title }}
+<draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()" class="row g-2">
+  <div v-for="(element, index) in data.elements" class="col-12">
+    <div class="card">
+      <div class="card-header pt-2 pb-1">
+        <a class="btn ps-0 pt-0 dragHandle">
+          <i class="<%= Icon::DRAG %> handle"></i>
         </a>
+        {{ element.title }}
+        <div class="float-end">
+          <a  class="btn btn-sm text-danger"
+              v-on:click="deleteElement(element)"
+              title="<%= t '.remove_element' %>">
+              <i class="<%= Icon::DELETE %>"></i>
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -19,7 +24,6 @@
 
 <%= osuny_separator %>
 
-<%= block_component_add_element block, t('.add_element') %>
 <div v-for="(element, index) in data.elements" class="row mb-4">
   <div class="col-sm-4">
     <%= block_component_edit block, :image, template: @element %>
@@ -31,12 +35,6 @@
       <%= block_component_edit block, :alt, template: @element %>
       <%= block_component_edit block, :credit, template: @element, summernote_config: 'mini' %>
     </div>
-    <a  class="btn btn-sm text-danger"
-        v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
-        title="<%= t '.remove_element' %>">
-        <i class="<%= Icon::DELETE %>"></i>
-        <%= t '.remove_element' %>
-    </a>
   </div>
 </div>
 <div v-show="data.elements.length > 2">

--- a/app/views/admin/communication/blocks/templates/files/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/files/_edit.html.erb
@@ -8,16 +8,15 @@
 
 <div v-show="data.elements.length > 1">
   <%= osuny_separator %>
-  <draggable  :list="data.elements"
-              @end="refreshSummernotes()"
-              handle=".dragHandle">
+  <draggable  :list="data.elements" handle=".dragHandle"
+              @end="refreshSummernotes()">
     <div v-for="(element, index) in data.elements" class="mb-2">
       <div class="card draggable-item dragHandle m-0">
         <div class="card-body d-flex align-items-center">
           <i class="<%= Icon::MOVE %> handle m-2"></i>
           <p class="mb-0">{{ element.title }}</p>
           <a  class="btn btn-sm text-danger ms-auto"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t '.remove_file' %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/files/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/files/_edit.html.erb
@@ -7,9 +7,7 @@
 <%= block_component_add_element block, t('.add_file') %>
 
 <div v-show="data.elements.length > 1">
-  <%= osuny_separator %>
-  <draggable  :list="data.elements" handle=".dragHandle"
-              @end="refreshSummernotes()">
+  <draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()">
     <div v-for="(element, index) in data.elements" class="mb-2">
       <div class="card draggable-item dragHandle m-0">
         <div class="card-body d-flex align-items-center">

--- a/app/views/admin/communication/blocks/templates/gallery/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/gallery/_edit.html.erb
@@ -14,9 +14,7 @@
 <%= osuny_separator %>
 
 <p><%= t('.move_images') %></p>
-<draggable  :list="data.elements"
-            class="row"
-            @end="refreshSummernotes()">
+<draggable :list="data.elements" @end="refreshSummernotes()" class="row">
   <div v-for="(element, index) in data.elements" class="col-2 mb-4">
     <div class="card">
       <div class="card-header p-1 text-center">

--- a/app/views/admin/communication/blocks/templates/jobs/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/jobs/_edit.html.erb
@@ -25,7 +25,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger ms-3"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t('delete') %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/key_figures/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/key_figures/_edit.html.erb
@@ -2,9 +2,7 @@
 
 <%= osuny_separator %>
 
-<draggable  class="row g-3 mb-3" 
-            :list="data.elements" 
-            handle=".dragHandle">
+<draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()" class="row g-3 mb-3">
   <div v-for="(element, index) in data.elements" class=" col-6 col-md-4">
     <div class="card draggable-item dragHandle m-0">
       <div class="card-body">
@@ -25,7 +23,7 @@
   <div class="col-sm-4">
     <%= block_component_edit block, :image, template: @element %>
     <a  class="btn btn-sm text-danger"
-        v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+        v-on:click="deleteElement(element)"
         title="<%= t '.remove_key' %>">
         <i class="<%= Icon::DELETE %>"></i>
         <%= t '.remove_key' %>

--- a/app/views/admin/communication/blocks/templates/links/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/links/_edit.html.erb
@@ -1,9 +1,9 @@
 <%= block_component_edit block, :description, summernote_config: 'mini' %>
 
-<%= osuny_separator %>
+<%= block_component_add_element block, t('.add') %>
 
 <p><%= t('.move_links') %></p>
-<draggable :list="data.elements" handle=".dragHandle" class="row g-2">
+<draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()" class="row g-2">
   <div v-for="(element, index) in data.elements" class="col-12">
     <div class="card">
       <div class="card-header pt-2 pb-1">
@@ -13,8 +13,8 @@
         {{ element.title }}
         <div class="float-end">
           <a  class="btn btn-sm text-danger"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
-              title="<%= t '.remove' %>">
+              v-on:click="deleteElement(element)"
+              title="<%= t 'delete' %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>
         </div>
@@ -24,8 +24,6 @@
 </draggable>
 
 <%= osuny_separator %>
-
-<%= block_component_add_element block, t('.add') %>
 
 <div v-for="(element, index) in data.elements" class="mb-4">
   <%= block_component_edit block, :title, template: @element %>

--- a/app/views/admin/communication/blocks/templates/locations/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/locations/_edit.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div>
       <a  class="btn btn-sm text-danger ms-3"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+          v-on:click="deleteElement(element)"
           title="Supprimer">
           <i class="<%= Icon::DELETE %>"></i>
       </a>

--- a/app/views/admin/communication/blocks/templates/organizations/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/organizations/_edit.html.erb
@@ -12,7 +12,7 @@
     <%= t('admin.communication.blocks.templates.organizations.edit.unregistered_organizations_on_map_warning') %>
   </div>
 
-  <draggable :list="data.elements" class="mb-3" handle=".partnerHandle">
+  <draggable :list="data.elements" handle=".partnerHandle" class="mb-3">
     <div v-for="(element, index) in data.elements" class="draggable-item">
       <div class="d-flex mb-n3">
         <div>
@@ -41,7 +41,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger ps-0 ms-3"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t('delete') %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/pages/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/pages/_edit.html.erb
@@ -25,7 +25,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger ms-3"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t('delete') %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/papers/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/papers/_edit.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger ms-3"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="Supprimer">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/persons/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/persons/_edit.html.erb
@@ -8,7 +8,7 @@
 <div v-if="data.mode === 'selection'">
   <div><%= osuny_label University::Person.model_name.human(count: 2) %></div>
   <%= block_component_add_element block, t('.add_person') %>
-  <draggable :list="data.elements" class="mb-3" handle=".dragHandle">
+  <draggable :list="data.elements" handle=".dragHandle" class="mb-3">
     <div v-for="(element, index) in data.elements" class="draggable-item">
       <div class="d-flex">
         <div>
@@ -28,7 +28,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t('delete') %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/posts/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/posts/_edit.html.erb
@@ -19,7 +19,7 @@
         <%= block_component_edit block, :id, template: @element %>
       </div>
       <a  class="btn text-danger ms-3"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+          v-on:click="deleteElement(element)"
           title="<%= t('delete') %>">
           <i class="<%= Icon::DELETE %>"></i>
       </a>

--- a/app/views/admin/communication/blocks/templates/programs/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/programs/_edit.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div>
       <a  class="btn btn-sm text-danger ms-3"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+          v-on:click="deleteElement(element)"
           title="Supprimer">
           <i class="<%= Icon::DELETE %>"></i>
       </a>

--- a/app/views/admin/communication/blocks/templates/projects/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/projects/_edit.html.erb
@@ -18,7 +18,7 @@
         <%= block_component_edit block, :id, template: @element %>
       </div>
       <a  class="btn text-danger ms-3"
-          v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+          v-on:click="deleteElement(element)"
           title="<%= t('delete') %>">
           <i class="<%= Icon::DELETE %>"></i>
       </a>

--- a/app/views/admin/communication/blocks/templates/testimonials/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/testimonials/_edit.html.erb
@@ -2,9 +2,7 @@
 
 <div v-show="data.elements.length > 0">
   <%= osuny_separator %>
-  <draggable  :list="data.elements"
-              @end="refreshSummernotes()"
-              handle=".dragHandle">
+  <draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()">
     <div v-for="(element, index) in data.elements" class="mb-2">
       <div class="card draggable-item dragHandle m-0">
         <div class="card-body d-flex">
@@ -17,7 +15,7 @@
             </p>
           </div>
           <a  class="btn btn-sm text-danger ms-auto"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="<%= t '.remove_testimonial' %>">
               <i class="<%= Icon::DELETE %>"></i>
           </a>

--- a/app/views/admin/communication/blocks/templates/timeline/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/timeline/_edit.html.erb
@@ -1,10 +1,6 @@
 <%= block_component_add_element block, t('.add_event') %>
 
-<%= osuny_separator %>
-<draggable  class="mb-3"
-            :list="data.elements"
-            @end="refreshSummernotes()"
-            handle=".dragHandle">
+<draggable :list="data.elements" handle=".dragHandle" @end="refreshSummernotes()" class="mb-3">
   <div v-for="(element, index) in data.elements" class="mb-2">
     <div class="card draggable-item dragHandle m-0">
       <div class="card-body d-flex">

--- a/app/views/admin/communication/blocks/templates/volumes/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/volumes/_edit.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div>
           <a  class="btn btn-sm text-danger ms-3"
-              v-on:click="data.elements.splice(data.elements.indexOf(element), 1)"
+              v-on:click="deleteElement(element)"
               title="Supprimer">
               <i class="<%= Icon::DELETE %>"></i>
           </a>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fix #4009 fix #4006

Il manquait un `refreshSummernote()`. 
J'en ai profité pour harmoniser les `delete`, l'ordre des propriétés des `draggable` et l'UI du bloc Fonctionnalités.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
