### PR TITLE
Optimisation des opérations par lots

### DIFF
--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -31,20 +31,12 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   end
 
   def reorder
-    parent_page = @website.pages.find(params[:parentId])
-    old_parent_page = @website.pages.find(params[:oldParentId])
-    ids = params[:ids] || []
-    Osuny::BulkOperation.silently do
-      pages_by_id = @website.pages.where(id: ids).index_by(&:id)
-      ids.each.with_index do |id, index|
-        page = pages_by_id[id]
-        next if page.nil?
-        page.update(parent_id: parent_page.id, position: index + 1)
-      end
-    end
-    old_parent_page.touch
-    parent_page.touch if parent_page != old_parent_page
-    @website.generate_automatic_menus_for_language(current_language)
+    @website.reorder_pages(
+      previous_parent_id: params[:oldParentId], 
+      parent_id: params[:parentId], 
+      ids: params[:ids],
+      language: current_language
+    )
   end
 
   def children

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -8,7 +8,8 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   include Admin::Localizable
 
   before_action :load_localization,
-                :redirect_if_not_localized,
+                only: [:show, :edit, :update, :duplicate, :static, :publish, :preview, :generate_from_template]
+  before_action :redirect_if_not_localized,
                 only: [:show, :edit, :update, :static, :publish, :preview, :generate_from_template]
 
   def index
@@ -123,10 +124,11 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
 
   def duplicate
     if @page.is_special_page?
-      redirect_back(fallback_location: admin_communication_website_page_path(@page), alert: t('admin.communication.website.pages.duplicate_special_page_notice'))
+      redirect_back fallback_location: admin_communication_website_page_path(@page),
+                    alert: t('admin.communication.website.pages.duplicate_special_page_notice')
     else
       redirect_to [:admin, @page.duplicate],
-                  notice: t('admin.successfully_duplicated_html', model: @page.to_s)
+                  notice: t('admin.successfully_duplicated_html', model: @l10n.to_s)
     end
   end
 

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -34,9 +34,13 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
     parent_page = @website.pages.find(params[:parentId])
     old_parent_page = @website.pages.find(params[:oldParentId])
     ids = params[:ids] || []
-    ids.each.with_index do |id, index|
-      page = @website.pages.find(id)
-      page.update(parent_id: parent_page.id, position: index + 1)
+    BulkOperation.silently do
+      pages_by_id = @website.pages.where(id: ids).index_by(&:id)
+      ids.each.with_index do |id, index|
+        page = pages_by_id[id]
+        next if page.nil?
+        page.update(parent_id: parent_page.id, position: index + 1)
+      end
     end
     old_parent_page.touch
     parent_page.touch if parent_page != old_parent_page
@@ -144,7 +148,8 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   def restore
     @page = @website.pages.only_deleted.find(params[:id])
     authorize!(:restore, @page)
-    @page.restore(recursive: true)
+    BulkOperation.silently { @page.restore(recursive: true) }
+    @page.touch
     redirect_to admin_communication_website_page_path(@page),
                 notice: t('admin.successfully_restored_html', model: @page.to_s_in(current_language))
   end

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -34,7 +34,7 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
     parent_page = @website.pages.find(params[:parentId])
     old_parent_page = @website.pages.find(params[:oldParentId])
     ids = params[:ids] || []
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       pages_by_id = @website.pages.where(id: ids).index_by(&:id)
       ids.each.with_index do |id, index|
         page = pages_by_id[id]
@@ -148,7 +148,7 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   def restore
     @page = @website.pages.only_deleted.find(params[:id])
     authorize!(:restore, @page)
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       @page.restore(recursive: true)
     end
     @page.touch

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -148,8 +148,11 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   def restore
     @page = @website.pages.only_deleted.find(params[:id])
     authorize!(:restore, @page)
-    BulkOperation.silently { @page.restore(recursive: true) }
+    BulkOperation.silently do
+      @page.restore(recursive: true)
+    end
     @page.touch
+    @website.generate_automatic_menus_for_language(current_language)
     redirect_to admin_communication_website_page_path(@page),
                 notice: t('admin.successfully_restored_html', model: @page.to_s_in(current_language))
   end

--- a/app/jobs/communication/website/clean_after_pages_reorder_job.rb
+++ b/app/jobs/communication/website/clean_after_pages_reorder_job.rb
@@ -1,0 +1,12 @@
+class Communication::Website::CleanAfterPagesReorderJob < Communication::Website::BaseJob
+  queue_as :cats
+
+  def execute
+    @website.clean_after_pages_reorder_safely(
+      options[:previous_parent_id],
+      options[:parent_id],
+      options[:language]
+    )
+  end
+
+end

--- a/app/jobs/communication/website/direct_object/connect_dependencies_job.rb
+++ b/app/jobs/communication/website/direct_object/connect_dependencies_job.rb
@@ -1,0 +1,9 @@
+class Communication::Website::DirectObject::ConnectDependenciesJob < ApplicationJob
+  queue_as :cats
+
+  def perform(direct_object)
+    return if direct_object.paranoid? && direct_object.deleted?
+
+    direct_object.connect_dependencies_safely
+  end
+end

--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -158,7 +158,7 @@ class Communication::Block < ApplicationRecord
   end
 
   def touch_about
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     about.touch
   end
 

--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -158,7 +158,7 @@ class Communication::Block < ApplicationRecord
   end
 
   def touch_about
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     about.touch
   end
 

--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -158,6 +158,7 @@ class Communication::Block < ApplicationRecord
   end
 
   def touch_about
+    return if Duplicable.in_progress?
     about.touch
   end
 

--- a/app/models/communication/website/page.rb
+++ b/app/models/communication/website/page.rb
@@ -63,8 +63,6 @@ class Communication::Website::Page < ApplicationRecord
              foreign_key: :parent_id,
              dependent: :destroy
 
-  after_save :touch_elements_if_special_page_in_hierarchy
-
   scope :latest_in, -> (language) { published_now_in(language).order("communication_website_page_localizations.updated_at DESC").limit(5) }
 
   scope :ordered_by_title, -> (language) {
@@ -141,16 +139,5 @@ class Communication::Website::Page < ApplicationRecord
 
   def list_blocks_template_kind
     :pages
-  end
-
-  def touch_elements_if_special_page_in_hierarchy
-    # We do not call touch as we don't want to trigger the sync on the connected objects
-    descendants_and_self.each do |page|
-      if page.type == 'Communication::Website::Page::Person'
-        website.connected_people.update_all(updated_at: Time.zone.now)
-      elsif page.type == 'Communication::Website::Page::Organization'
-        website.connected_organizations.update_all(updated_at: Time.zone.now)
-      end
-    end
   end
 end

--- a/app/models/communication/website/page/with_automatic_menus.rb
+++ b/app/models/communication/website/page/with_automatic_menus.rb
@@ -9,7 +9,7 @@ module Communication::Website::Page::WithAutomaticMenus
   protected
 
   def generate_automatic_menus
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     website.generate_automatic_menus_for_identifier(default_menu_identifier)
   end
 end

--- a/app/models/communication/website/page/with_automatic_menus.rb
+++ b/app/models/communication/website/page/with_automatic_menus.rb
@@ -9,14 +9,7 @@ module Communication::Website::Page::WithAutomaticMenus
   protected
 
   def generate_automatic_menus
-    return if Duplicable.in_progress?
-    website.generate_automatic_menus_for_identifier(default_menu_identifier)
-  end
-
-  # Called by Duplicable#finalize_duplication once the duplication transaction
-  # has been committed, so that automatic menus are regenerated once instead
-  # of once per intermediate save during the duplication.
-  def generate_automatic_menus_after_duplication
+    return if BulkOperation.in_progress?
     website.generate_automatic_menus_for_identifier(default_menu_identifier)
   end
 end

--- a/app/models/communication/website/page/with_automatic_menus.rb
+++ b/app/models/communication/website/page/with_automatic_menus.rb
@@ -9,6 +9,14 @@ module Communication::Website::Page::WithAutomaticMenus
   protected
 
   def generate_automatic_menus
+    return if Duplicable.in_progress?
+    website.generate_automatic_menus_for_identifier(default_menu_identifier)
+  end
+
+  # Called by Duplicable#finalize_duplication once the duplication transaction
+  # has been committed, so that automatic menus are regenerated once instead
+  # of once per intermediate save during the duplication.
+  def generate_automatic_menus_after_duplication
     website.generate_automatic_menus_for_identifier(default_menu_identifier)
   end
 end

--- a/app/models/communication/website/with_connected_objects.rb
+++ b/app/models/communication/website/with_connected_objects.rb
@@ -21,7 +21,7 @@ module Communication::Website::WithConnectedObjects
   def clean_and_rebuild_safely
     direct_objects_association_names.each do |association_name|
       # We use find_each to avoid loading all the objects in memory
-      public_send(association_name).find_each(&:connect_dependencies)
+      public_send(association_name).find_each(&:connect_dependencies_safely)
     end
     indirect_objects_connected_to_website.each do |indirect_object|
       connect(indirect_object, self)

--- a/app/models/communication/website/with_menus.rb
+++ b/app/models/communication/website/with_menus.rb
@@ -54,9 +54,11 @@ module Communication::Website::WithMenus
   end
 
   def initialize_menus
-    languages.each do |language|
-      create_default_menus(language)
-      generate_automatic_menus_for_language(language)
+    BulkOperation.silently do
+      languages.each do |language|
+        create_default_menus(language)
+        generate_automatic_menus_for_language(language)
+      end
     end
   end
 

--- a/app/models/communication/website/with_menus.rb
+++ b/app/models/communication/website/with_menus.rb
@@ -54,7 +54,7 @@ module Communication::Website::WithMenus
   end
 
   def initialize_menus
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       languages.each do |language|
         create_default_menus(language)
         generate_automatic_menus_for_language(language)

--- a/app/models/communication/website/with_pages.rb
+++ b/app/models/communication/website/with_pages.rb
@@ -28,6 +28,33 @@ module Communication::Website::WithPages
     end
   end
 
+  def reorder_pages(previous_parent_id:, parent_id:, ids: [], language:)
+    Osuny::BulkOperation.silently do
+      pages_by_id = pages.where(id: ids).index_by(&:id)
+      ids.each.with_index do |id, index|
+        page = pages_by_id[id]
+        next if page.nil?
+        page.update(parent_id: parent_id, position: index + 1)
+      end
+    end
+    Communication::Website::CleanAfterPagesReorderJob.perform_later(id, {
+      previous_parent_id: previous_parent_id,
+      parent_id: parent_id,
+      language: language
+    })
+  end
+
+  def clean_after_pages_reorder_safely(previous_parent_id, parent_id, language)
+    parent = pages.find(parent_id)
+    pages_to_touch = previous_parent.descendants_and_self
+    if previous_parent_id != parent_id
+      previous_parent = pages.find(previous_parent_id)
+      pages_to_touch += parent.descendants_and_self 
+    end
+    pages_to_touch.uniq.each(&:touch)
+    generate_automatic_menus_for_language(language)
+  end
+
   protected
 
   def find_special_page(type)

--- a/app/models/communication/website/with_pages.rb
+++ b/app/models/communication/website/with_pages.rb
@@ -46,10 +46,10 @@ module Communication::Website::WithPages
 
   def clean_after_pages_reorder_safely(previous_parent_id, parent_id, language)
     parent = pages.find(parent_id)
-    pages_to_touch = previous_parent.descendants_and_self
+    pages_to_touch = parent.descendants_and_self
     if previous_parent_id != parent_id
       previous_parent = pages.find(previous_parent_id)
-      pages_to_touch += parent.descendants_and_self 
+      pages_to_touch += previous_parent.descendants_and_self 
     end
     pages_to_touch.uniq.each(&:touch)
     generate_automatic_menus_for_language(language)

--- a/app/models/concerns/as_direct_object.rb
+++ b/app/models/concerns/as_direct_object.rb
@@ -38,7 +38,7 @@ module AsDirectObject
   end
 
   def connect_dependencies
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     Communication::Website::DirectObject::ConnectDependenciesJob.perform_later(self)
   end
 

--- a/app/models/concerns/as_direct_object.rb
+++ b/app/models/concerns/as_direct_object.rb
@@ -37,9 +37,6 @@ module AsDirectObject
     website.id == communication_website_id
   end
 
-  # Enqueued from after_save / after_touch callbacks. The synchronous
-  # implementation lives in connect_dependencies_safely and is invoked
-  # by Communication::Website::DirectObject::ConnectDependenciesJob.
   def connect_dependencies
     return if BulkOperation.in_progress?
     Communication::Website::DirectObject::ConnectDependenciesJob.perform_later(self)

--- a/app/models/concerns/as_direct_object.rb
+++ b/app/models/concerns/as_direct_object.rb
@@ -38,6 +38,7 @@ module AsDirectObject
   end
 
   def connect_dependencies
+    return if Duplicable.in_progress?
     dependencies.each do |dependency|
       website.connect(dependency, self)
     end

--- a/app/models/concerns/as_direct_object.rb
+++ b/app/models/concerns/as_direct_object.rb
@@ -37,8 +37,15 @@ module AsDirectObject
     website.id == communication_website_id
   end
 
+  # Enqueued from after_save / after_touch callbacks. The synchronous
+  # implementation lives in connect_dependencies_safely and is invoked
+  # by Communication::Website::DirectObject::ConnectDependenciesJob.
   def connect_dependencies
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
+    Communication::Website::DirectObject::ConnectDependenciesJob.perform_later(self)
+  end
+
+  def connect_dependencies_safely
     dependencies.each do |dependency|
       website.connect(dependency, self)
     end

--- a/app/models/concerns/as_indirect_object.rb
+++ b/app/models/concerns/as_indirect_object.rb
@@ -96,7 +96,7 @@ module AsIndirectObject
   end
 
   def connect_to_websites
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     Communication::Website::IndirectObject::ConnectToWebsitesJob.perform_later self
   end
 

--- a/app/models/concerns/as_indirect_object.rb
+++ b/app/models/concerns/as_indirect_object.rb
@@ -96,6 +96,7 @@ module AsIndirectObject
   end
 
   def connect_to_websites
+    return if Duplicable.in_progress?
     Communication::Website::IndirectObject::ConnectToWebsitesJob.perform_later self
   end
 

--- a/app/models/concerns/as_indirect_object.rb
+++ b/app/models/concerns/as_indirect_object.rb
@@ -96,7 +96,7 @@ module AsIndirectObject
   end
 
   def connect_to_websites
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     Communication::Website::IndirectObject::ConnectToWebsitesJob.perform_later self
   end
 

--- a/app/models/concerns/as_tree.rb
+++ b/app/models/concerns/as_tree.rb
@@ -51,7 +51,7 @@ module AsTree
   end
 
   def update_position_in_tree_later
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     return unless respond_to?(:position_in_tree)
     Tree::UpdatePositionJob.set(wait: 1.minute).perform_later(
       university,

--- a/app/models/concerns/as_tree.rb
+++ b/app/models/concerns/as_tree.rb
@@ -51,6 +51,7 @@ module AsTree
   end
 
   def update_position_in_tree_later
+    return if Duplicable.in_progress?
     return unless respond_to?(:position_in_tree)
     Tree::UpdatePositionJob.set(wait: 1.minute).perform_later(
       university,

--- a/app/models/concerns/as_tree.rb
+++ b/app/models/concerns/as_tree.rb
@@ -51,7 +51,7 @@ module AsTree
   end
 
   def update_position_in_tree_later
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     return unless respond_to?(:position_in_tree)
     Tree::UpdatePositionJob.set(wait: 1.minute).perform_later(
       university,

--- a/app/models/concerns/bulk_operation.rb
+++ b/app/models/concerns/bulk_operation.rb
@@ -1,0 +1,17 @@
+module BulkOperation
+  IN_PROGRESS_KEY = :osuny_bulk_operation_in_progress
+
+  def self.in_progress?
+    Thread.current[IN_PROGRESS_KEY] == true
+  end
+
+  def self.silently(&block)
+    previous = Thread.current[IN_PROGRESS_KEY]
+    Thread.current[IN_PROGRESS_KEY] = true
+    ActiveRecord::Base.transaction(&block)
+  ensure
+    # To allow nested calls of silently
+    # Only the first call resets to false
+    Thread.current[IN_PROGRESS_KEY] = previous
+  end
+end

--- a/app/models/concerns/contentful.rb
+++ b/app/models/concerns/contentful.rb
@@ -36,7 +36,7 @@ module Contentful
   end
 
   def generate_blocks(template_blocks)
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       template_blocks.each { |hash| generate_block(hash.dup) }
     end
     about.touch
@@ -49,7 +49,7 @@ module Contentful
 
   def reset_blocks
     return unless resetable_blocks?
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       blocks.destroy_all
       about.duplicate_blocks(original, self)
     end

--- a/app/models/concerns/contentful.rb
+++ b/app/models/concerns/contentful.rb
@@ -39,6 +39,7 @@ module Contentful
     BulkOperation.silently do
       template_blocks.each { |hash| generate_block(hash.dup) }
     end
+    about.touch
   end
 
   def resetable_blocks?

--- a/app/models/concerns/contentful.rb
+++ b/app/models/concerns/contentful.rb
@@ -36,7 +36,9 @@ module Contentful
   end
 
   def generate_blocks(template_blocks)
-    template_blocks.each { |hash| generate_block(hash.dup) }
+    BulkOperation.silently do
+      template_blocks.each { |hash| generate_block(hash.dup) }
+    end
   end
 
   def resetable_blocks?
@@ -46,8 +48,11 @@ module Contentful
 
   def reset_blocks
     return unless resetable_blocks?
-    blocks.destroy_all
-    about.duplicate_blocks(original, self)
+    BulkOperation.silently do
+      blocks.destroy_all
+      about.duplicate_blocks(original, self)
+    end
+    about.touch
   end
 
   protected

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -1,10 +1,35 @@
 module Duplicable
   extend ActiveSupport::Concern
 
+  # Thread-local flag read by side-effect callbacks (clean websites,
+  # connect to websites, identify git files, synchronize list blocks,
+  # update tree position, connect dependencies, automatic menus, touch about)
+  # to skip themselves while a duplication is in progress.
+  # The work is performed once at the end of the duplication, in finalize_duplication.
+  IN_PROGRESS_KEY = :duplicable_in_progress
+
+  def self.in_progress?
+    Thread.current[IN_PROGRESS_KEY] == true
+  end
+
+  def self.in_progress
+    previous = Thread.current[IN_PROGRESS_KEY]
+    Thread.current[IN_PROGRESS_KEY] = true
+    yield
+  ensure
+    Thread.current[IN_PROGRESS_KEY] = previous
+  end
+
   def duplicate
-    instance = duplicate_instance
-    duplicate_categories_for(instance)
-    duplicate_localizations_for(instance)
+    instance = nil
+    ActiveRecord::Base.transaction do
+      Duplicable.in_progress do
+        instance = duplicate_instance
+        duplicate_categories_for(instance)
+        duplicate_localizations_for(instance)
+      end
+    end
+    finalize_duplication(instance)
     instance
   end
 
@@ -48,9 +73,26 @@ module Duplicable
   end
 
   def duplicate_block(instance, block)
-    duplicated_block = block.duplicate
+    duplicated_block = block.dup
     duplicated_block.about = instance
     duplicated_block.position = block.position
     duplicated_block.save
+  end
+
+  # Once the duplication has been fully committed, trigger the side-effect
+  # callbacks exactly once for the new instance. This replaces the per-save
+  # cascade that was firing N times (one per localization, one per block).
+  def finalize_duplication(instance)
+    return if instance.nil?
+    # touch fires after_touch callbacks: connect_dependencies (sync),
+    # identify_git_files, synchronize_list_blocks, update_position_in_tree_later,
+    # connect_to_websites (for indirect objects). All have been skipped during
+    # the duplication via Duplicable.in_progress?, so they run here only once.
+    instance.touch
+    # after_save-only callbacks need explicit re-firing:
+    Dependencies::CleanWebsitesIfNecessaryJob.perform_later(instance)
+    if instance.respond_to?(:generate_automatic_menus_after_duplication, true)
+      instance.send(:generate_automatic_menus_after_duplication)
+    end
   end
 end

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -3,7 +3,7 @@ module Duplicable
 
   def duplicate
     instance = nil
-    BulkOperation.silently do
+    Osuny::BulkOperation.silently do
       instance = duplicate_instance
       duplicate_categories_for(instance)
       duplicate_localizations_for(instance)

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -1,35 +1,14 @@
 module Duplicable
   extend ActiveSupport::Concern
 
-  # Thread-local flag read by side-effect callbacks (clean websites,
-  # connect to websites, identify git files, synchronize list blocks,
-  # update tree position, connect dependencies, automatic menus, touch about)
-  # to skip themselves while a duplication is in progress.
-  # The work is performed once at the end of the duplication, in finalize_duplication.
-  IN_PROGRESS_KEY = :duplicable_in_progress
-
-  def self.in_progress?
-    Thread.current[IN_PROGRESS_KEY] == true
-  end
-
-  def self.in_progress
-    previous = Thread.current[IN_PROGRESS_KEY]
-    Thread.current[IN_PROGRESS_KEY] = true
-    yield
-  ensure
-    Thread.current[IN_PROGRESS_KEY] = previous
-  end
-
   def duplicate
     instance = nil
-    ActiveRecord::Base.transaction do
-      Duplicable.in_progress do
-        instance = duplicate_instance
-        duplicate_categories_for(instance)
-        duplicate_localizations_for(instance)
-      end
+    BulkOperation.silently do
+      instance = duplicate_instance
+      duplicate_categories_for(instance)
+      duplicate_localizations_for(instance)
     end
-    finalize_duplication(instance)
+    instance.touch
     instance
   end
 
@@ -77,22 +56,5 @@ module Duplicable
     duplicated_block.about = instance
     duplicated_block.position = block.position
     duplicated_block.save
-  end
-
-  # Once the duplication has been fully committed, trigger the side-effect
-  # callbacks exactly once for the new instance. This replaces the per-save
-  # cascade that was firing N times (one per localization, one per block).
-  def finalize_duplication(instance)
-    return if instance.nil?
-    # touch fires after_touch callbacks: connect_dependencies (sync),
-    # identify_git_files, synchronize_list_blocks, update_position_in_tree_later,
-    # connect_to_websites (for indirect objects). All have been skipped during
-    # the duplication via Duplicable.in_progress?, so they run here only once.
-    instance.touch
-    # after_save-only callbacks need explicit re-firing:
-    Dependencies::CleanWebsitesIfNecessaryJob.perform_later(instance)
-    if instance.respond_to?(:generate_automatic_menus_after_duplication, true)
-      instance.send(:generate_automatic_menus_after_duplication)
-    end
   end
 end

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -23,6 +23,7 @@ module Duplicable
 
   def duplicate_instance
     instance = self.dup
+    instance.position = nil if instance.respond_to?(:position)
     instance.save
     instance
   end

--- a/app/models/concerns/generates_git_files.rb
+++ b/app/models/concerns/generates_git_files.rb
@@ -18,7 +18,7 @@ module GeneratesGitFiles
   protected
 
   def identify_git_files
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     Communication::Website::GitFile::IdentifyJob.perform_later(self)
   end
 end

--- a/app/models/concerns/generates_git_files.rb
+++ b/app/models/concerns/generates_git_files.rb
@@ -18,6 +18,7 @@ module GeneratesGitFiles
   protected
 
   def identify_git_files
+    return if Duplicable.in_progress?
     Communication::Website::GitFile::IdentifyJob.perform_later(self)
   end
 end

--- a/app/models/concerns/generates_git_files.rb
+++ b/app/models/concerns/generates_git_files.rb
@@ -18,7 +18,7 @@ module GeneratesGitFiles
   protected
 
   def identify_git_files
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     Communication::Website::GitFile::IdentifyJob.perform_later(self)
   end
 end

--- a/app/models/concerns/has_list_blocks.rb
+++ b/app/models/concerns/has_list_blocks.rb
@@ -11,6 +11,7 @@ module HasListBlocks
   protected
 
   def synchronize_list_blocks
+    return if Duplicable.in_progress?
     websites.each do |website|
       Communication::Website::SynchronizeListBlocksJob.perform_later(website, list_blocks_template_kind)
     end

--- a/app/models/concerns/has_list_blocks.rb
+++ b/app/models/concerns/has_list_blocks.rb
@@ -11,7 +11,7 @@ module HasListBlocks
   protected
 
   def synchronize_list_blocks
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     websites.each do |website|
       Communication::Website::SynchronizeListBlocksJob.perform_later(website, list_blocks_template_kind)
     end

--- a/app/models/concerns/has_list_blocks.rb
+++ b/app/models/concerns/has_list_blocks.rb
@@ -11,7 +11,7 @@ module HasListBlocks
   protected
 
   def synchronize_list_blocks
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     websites.each do |website|
       Communication::Website::SynchronizeListBlocksJob.perform_later(website, list_blocks_template_kind)
     end

--- a/app/models/concerns/with_dependencies.rb
+++ b/app/models/concerns/with_dependencies.rb
@@ -116,7 +116,7 @@ module WithDependencies
   end
 
   def clean_websites_if_necessary
-    return if BulkOperation.in_progress?
+    return if Osuny::BulkOperation.in_progress?
     Dependencies::CleanWebsitesIfNecessaryJob.perform_later(self)
   end
 

--- a/app/models/concerns/with_dependencies.rb
+++ b/app/models/concerns/with_dependencies.rb
@@ -116,7 +116,7 @@ module WithDependencies
   end
 
   def clean_websites_if_necessary
-    return if Duplicable.in_progress?
+    return if BulkOperation.in_progress?
     Dependencies::CleanWebsitesIfNecessaryJob.perform_later(self)
   end
 

--- a/app/models/concerns/with_dependencies.rb
+++ b/app/models/concerns/with_dependencies.rb
@@ -116,6 +116,7 @@ module WithDependencies
   end
 
   def clean_websites_if_necessary
+    return if Duplicable.in_progress?
     Dependencies::CleanWebsitesIfNecessaryJob.perform_later(self)
   end
 

--- a/app/services/osuny/bulk_operation.rb
+++ b/app/services/osuny/bulk_operation.rb
@@ -1,4 +1,4 @@
-module BulkOperation
+class Osuny::BulkOperation
   IN_PROGRESS_KEY = :osuny_bulk_operation_in_progress
 
   def self.in_progress?

--- a/test/models/communication/website/connection_test.rb
+++ b/test/models/communication/website/connection_test.rb
@@ -47,6 +47,7 @@ class Communication::Website::ConnectionTest < ActiveSupport::TestCase
     # On dépublie la page ayant un bloc chapitre : +0
     assert_no_difference("Communication::Website::Connection.count") do
       page_l10n.update(published: false)
+      perform_enqueued_jobs
     end
   end
 
@@ -114,6 +115,7 @@ class Communication::Website::ConnectionTest < ActiveSupport::TestCase
     block = second_page_l10n.blocks.new(position: 1, published: true, template_kind: :organizations)
     block.data = "{ \"mode\": \"selection\", \"elements\": [ { \"id\": \"#{noesya.id}\" } ] }"
     block.save
+    perform_enqueued_jobs
 
     # noesya est connectée via les 2 pages, donc 2 connexions
     assert_equal 2, page_l10n.website.connections.where(indirect_object: noesya).count
@@ -204,6 +206,7 @@ class Communication::Website::ConnectionTest < ActiveSupport::TestCase
     # On connecte la localisation à la page : +1
     assert_difference -> { page.connections.count } => 1 do
       page_l10n.about.save
+      perform_enqueued_jobs
     end
 
     # On ajoute un block "Chapitre" : +1
@@ -257,6 +260,8 @@ class Communication::Website::ConnectionTest < ActiveSupport::TestCase
       block.save
       perform_enqueued_jobs
     end
+
+    perform_enqueued_jobs
 
     # La page est donc comme ceci
     # Page

--- a/test/models/communication/website/dependency_test.rb
+++ b/test/models/communication/website/dependency_test.rb
@@ -33,11 +33,10 @@ class Communication::Website::DependencyTest < ActiveSupport::TestCase
     block = page_l10n.blocks.create(position: 1, published: true, template_kind: :persons)
     block.data = "{ \"elements\": [ { \"id\": \"#{arnaud.id}\" } ] }"
     block.save
+    perform_enqueued_jobs
 
     page = page.reload
     assert_equal 5, page.recursive_dependencies(skip_direct: false).count
-
-    clear_enqueued_jobs
 
     # On modifie le target du block
     block.data = "{ \"elements\": [ { \"id\": \"#{olivia.id}\" } ] }"

--- a/test/models/communication/website/git_file_test.rb
+++ b/test/models/communication/website/git_file_test.rb
@@ -67,6 +67,7 @@ class Communication::Website::GitFileTest < ActiveSupport::TestCase
     block = page_l10n.blocks.create(position: 1, published: true, template_kind: :persons)
     block.data = "{ \"elements\": [ { \"id\": \"#{arnaud.id}\" } ] }"
     block.save
+    perform_enqueued_jobs(except: Communication::Website::GitFile::IdentifyJob)
 
     page = page.reload
 
@@ -86,14 +87,10 @@ class Communication::Website::GitFileTest < ActiveSupport::TestCase
       block.save
     end
 
-    # On lance l'identification pour Olivia
     assert_difference -> { olivia.original_localization.git_files.count } do
-      perform_enqueued_jobs(only: Communication::Website::GitFile::IdentifyJob)
-    end
-
-    # On vérifie qu'on enqueue le job qui clean les websites
-    assert_enqueued_with(job: Communication::Website::CleanJob) do
-      perform_enqueued_jobs(only: Dependencies::CleanWebsitesIfNecessaryJob)
+      assert_enqueued_with(job: Communication::Website::CleanJob) do
+        perform_enqueued_jobs
+      end
     end
       
     perform_enqueued_jobs(only: Communication::Website::CleanJob)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

De nombreuses opérations, dont la duplication, font trop de choses en cascade. 
Il s'agit là de suspendre les callbacks pendant ces opérations, et de les regrouper dans une transaction afin d'éviter les états instables des données.

### Tests

- [x] tâches classiques
  - [x] ajout un blocs orga -> vérifier que l'orga est bien connectée à la fin des tâches
- [x] reorder des pages
- [x] reset blocks
- [x] génération de blocs (a11y)
- [x] duplication d'une page avec plein de blocs

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
