### PR TITLE
Amélioration des boutons d'enregistrement des réglages

### DIFF
--- a/app/views/admin/communication/websites/edit.html.erb
+++ b/app/views/admin/communication/websites/edit.html.erb
@@ -61,9 +61,7 @@
                       preview: 300 %>
       </div>
     </div>
-    <% content_for :action_bar_right do %>
-      <%= cancel [:admin, @website] %>
-      <%= submit f %>
-    <% end %>
+    <%= osuny_separator %>
+    <%= submit f %>
   <% end %>
 <% end %>

--- a/app/views/admin/communication/websites/settings/federation.html.erb
+++ b/app/views/admin/communication/websites/settings/federation.html.erb
@@ -15,11 +15,8 @@
         <%= f.association :source_websites,
                           collection: @source_websites,
                           as: :check_boxes %>
-
-        <% content_for :action_bar_right do %>
-          <%= cancel [:admin, @website] %>
-          <%= submit f %>
-        <% end %>
+                          
+        <%= submit f %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/admin/communication/websites/settings/language.html.erb
+++ b/app/views/admin/communication/websites/settings/language.html.erb
@@ -18,19 +18,15 @@
       </div>
       <div class="col-lg-8">
         <%= render 'admin/application/contact_details/edit', f: f, lf: lf, about: @website, l10n: @l10n %>
+        <%= submit f %>
         <%= osuny_separator %>
       </div>
     </div>
-    <div class="row">
-      <div class="offset-lg-4 col-lg-8 col-xxl-6">
-        <p><%= t('admin.communication.blocks.footer') %></p>
-      </div>
-    </div>
-    <%= render 'admin/communication/blocks/group/editor', about: @l10n %>
-
-    <% content_for :action_bar_right do %>
-      <%= cancel [:admin, @website] %>
-      <%= submit f %>
-    <% end %>
   <% end %>
 <% end %>
+<div class="row">
+  <div class="offset-lg-4 col-lg-8 col-xxl-6">
+    <p><%= t('admin.communication.blocks.footer') %></p>
+  </div>
+</div>
+<%= render 'admin/communication/blocks/group/editor', about: @l10n %>

--- a/app/views/admin/communication/websites/settings/technical.html.erb
+++ b/app/views/admin/communication/websites/settings/technical.html.erb
@@ -67,9 +67,6 @@
       </div>
     </div>
 
-    <% content_for :action_bar_right do %>
-      <%= cancel [:admin, @website] %>
-      <%= submit f %>
-    <% end %>
+    <%= submit f %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

### Le problème

Bug signalé par Clémentine
<img width="1433" height="917" alt="image" src="https://github.com/user-attachments/assets/8483ff59-ac1c-47e4-b06b-66c11dde5662" />

C'est moche, et en plus ça bloque l'enregistrement des blocs de footer.


### La solution

Réglages
<img width="1790" height="873" alt="Capture d’écran 2026-06-05 à 17 11 35" src="https://github.com/user-attachments/assets/818d3ee8-6c2a-4a13-9f78-2a274fb10299" />

Français
<img width="1792" height="975" alt="Capture d’écran 2026-06-05 à 17 11 52" src="https://github.com/user-attachments/assets/cd21c909-fe28-497e-9049-0dd1cefde08d" />

Fédération 
<img width="1792" height="974" alt="Capture d’écran 2026-06-05 à 17 12 06" src="https://github.com/user-attachments/assets/074c947f-97f4-43d3-943f-2566269b57b2" />

Technique
<img width="1792" height="725" alt="Capture d’écran 2026-06-05 à 17 12 31" src="https://github.com/user-attachments/assets/2076d262-318b-4c5f-865e-0a4f338ae4c9" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
