### PR TITLE
Empêche de déplacer une page spéciale en dehors du niveau racine

### DIFF
--- a/app/assets/javascripts/admin/plugins/treeview.js
+++ b/app/assets/javascripts/admin/plugins/treeview.js
@@ -20,6 +20,16 @@ window.osuny.treeView = {
                 animation: 150,
                 fallbackOnBody: true,
                 swapThreshold: 0.65,
+                onMove: function (evt) {
+                    var dragged = evt.dragged,
+                        to = evt.to;
+                    // prevent moving special pages
+                    if (dragged.dataset.special === 'true' &&
+                            to.classList.contains('js-treeview-children')) {
+                        return false;
+                    }
+                    return true;
+                },
                 onEnd: function (evt) {
                     var item = evt.item,
                         from = evt.from,

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -33,7 +33,7 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   def reorder
     item = @website.pages.find(params[:itemId])
     # Bug prevention: prevent moving special pages into children
-    if item.is_special_page? && params[:parentId] != @website.special_page(Communication::Website::Page::Home).id.to_s
+    if item.is_special_page? && params[:parentId] != item.default_parent.id.to_s
       return head :unprocessable_entity
     end
 

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -31,6 +31,12 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   end
 
   def reorder
+    item = @website.pages.find(params[:itemId])
+    # Bug prevention: prevent moving special pages into children
+    if item.is_special_page? && params[:parentId] != @website.special_page(Communication::Website::Page::Home).id.to_s
+      return head :unprocessable_entity
+    end
+
     @website.reorder_pages(
       previous_parent_id: params[:oldParentId], 
       parent_id: params[:parentId], 

--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -33,8 +33,9 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
   def reorder
     item = @website.pages.find(params[:itemId])
     # Bug prevention: prevent moving special pages into children
-    if item.is_special_page? && params[:parentId] != item.default_parent.id.to_s
-      return head :unprocessable_entity
+    if item.is_special_page? && params[:parentId] != item.default_parent.id
+      head :unprocessable_entity
+      return 
     end
 
     @website.reorder_pages(

--- a/app/models/communication/website/page/administrator.rb
+++ b/app/models/communication/website/page/administrator.rb
@@ -23,6 +23,10 @@ class Communication::Website::Page::Administrator < Communication::Website::Page
     'administrators/_index.html'
   end
 
+  def default_parent
+    website.special_page(Communication::Website::Page::Person)
+  end
+  
   protected
 
   def dependencies_administrators
@@ -32,7 +36,4 @@ class Communication::Website::Page::Administrator < Communication::Website::Page
     )
   end
 
-  def default_parent
-    website.special_page(Communication::Website::Page::Person)
-  end
 end

--- a/app/models/communication/website/page/author.rb
+++ b/app/models/communication/website/page/author.rb
@@ -19,6 +19,10 @@ class Communication::Website::Page::Author < Communication::Website::Page
     'authors/_index.html'
   end
 
+  def default_parent
+    website.special_page(Communication::Website::Page::Person)
+  end
+  
   protected
 
   def dependencies_authors
@@ -28,7 +32,4 @@ class Communication::Website::Page::Author < Communication::Website::Page
     )
   end
 
-  def default_parent
-    website.special_page(Communication::Website::Page::Person)
-  end
 end

--- a/app/models/communication/website/page/researcher.rb
+++ b/app/models/communication/website/page/researcher.rb
@@ -23,6 +23,10 @@ class Communication::Website::Page::Researcher < Communication::Website::Page
     'researchers/_index.html'
   end
 
+  def default_parent
+    website.special_page(Communication::Website::Page::Person)
+  end
+  
   protected
 
   def dependencies_researchers
@@ -32,7 +36,4 @@ class Communication::Website::Page::Researcher < Communication::Website::Page
     )
   end
 
-  def default_parent
-    website.special_page(Communication::Website::Page::Person)
-  end
 end

--- a/app/models/communication/website/page/teacher.rb
+++ b/app/models/communication/website/page/teacher.rb
@@ -23,6 +23,10 @@ class Communication::Website::Page::Teacher < Communication::Website::Page
     'teachers/_index.html'
   end
 
+  def default_parent
+    website.special_page(Communication::Website::Page::Person)
+  end
+  
   protected
 
   def dependencies_teachers
@@ -32,7 +36,4 @@ class Communication::Website::Page::Teacher < Communication::Website::Page
     )
   end
 
-  def default_parent
-    website.special_page(Communication::Website::Page::Person)
-  end
 end

--- a/app/models/communication/website/page/with_special_page.rb
+++ b/app/models/communication/website/page/with_special_page.rb
@@ -123,11 +123,12 @@ module Communication::Website::Page::WithSpecialPage
     save if l10n_created
   end
 
-  protected
-
   def default_parent
     website.special_page(Communication::Website::Page::Home)
   end
+  
+  protected
+
 
   def initialize_special_page
     # Set default attributes for special page

--- a/app/views/admin/communication/websites/pages/_form.html.erb
+++ b/app/views/admin/communication/websites/pages/_form.html.erb
@@ -37,7 +37,7 @@ url = page.new_record?  ? admin_communication_website_pages_path
                               except: page,
                               localized: true
                             ),
-                            include_blank: false unless page.is_home? %>
+                            include_blank: false unless page.is_special_page? %>
           <%= f.input :bodyclass, label: t('admin.bodyclass') if can?(:edit, @website) %>
           <%= f.input :full_width if page.editable_width? %>
         <% end %>

--- a/app/views/admin/communication/websites/pages/_treebranch.html.erb
+++ b/app/views/admin/communication/websites/pages/_treebranch.html.erb
@@ -5,7 +5,8 @@
               <%= 'treeview__element--draft' unless page.published_in?(current_language) %>
               <%= 'treeview__element--empty' unless page.has_children? %>"
       data-id="<%= page.id %>"
-      data-parent="<%= page.parent_id %>">
+      data-parent="<%= page.parent_id %>"
+      data-special="<%= page.is_special_page? %>">
     <div class="<%= osuny_card_classes(horizontal: true) %> treeview__label">
       <%= link_to children_admin_communication_website_page_path(website_id: page.website.id, id: page.id),
                   class: 'js-treeview-openzone d-inline-block', remote: true do %>


### PR DESCRIPTION
…first level)

## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Empêche de déplacer une page spéciale en dehors du niveau racine.
Blocage côté JS et côté RoR

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
