### PR TITLE
Host correct sur les mails de déblocage

### DIFF
--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -88,6 +88,16 @@ module User::WithAuthentication
       end
     end
 
+    def send_devise_notification(notification, *args)
+      if notification == :unlock_instructions
+        host = Thread.current[:osuny_registration_context_host]
+        if registration_context.blank? && host.present?
+          self.registration_context = Communication::Extranet.with_host(host) || University.with_host(host) || university
+        end
+      end
+      super(notification, *args)
+    end
+
     def unlock_mfa!
       self.update_column(:second_factor_attempts_count, 0)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module Osuny
     config.i18n.enforce_available_locales = false
     config.i18n.load_path += Dir["#{Rails.root.to_s}/config/locales/**/*.yml"]
 
-    config.internal_domains = ['@noesya.coop'].freeze
+    config.internal_domains = ['@noesya.coop', '@osuny.org'].freeze
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {

--- a/config/initializers/request_host_context_middleware.rb
+++ b/config/initializers/request_host_context_middleware.rb
@@ -1,0 +1,3 @@
+require Rails.root.join("lib/request_host_context_middleware")
+
+Rails.application.config.middleware.insert_before Warden::Manager, RequestHostContextMiddleware

--- a/lib/request_host_context_middleware.rb
+++ b/lib/request_host_context_middleware.rb
@@ -1,0 +1,14 @@
+class RequestHostContextMiddleware
+  THREAD_REGISTRATION_CONTEXT_HOST_KEY = :osuny_registration_context_host
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    Thread.current[THREAD_REGISTRATION_CONTEXT_HOST_KEY] = Rack::Request.new(env).host
+    @app.call(env)
+  ensure
+    Thread.current[THREAD_REGISTRATION_CONTEXT_HOST_KEY] = nil
+  end
+end

--- a/test/controllers/users/unlocks_controller_test.rb
+++ b/test/controllers/users/unlocks_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Users::UnlocksControllerTest < ActionDispatch::IntegrationTest
+  def test_extranet_unlock_instructions_mail_uses_extranet_host
+    host! default_extranet.host
+    user = users(:alumnus)
+    user.lock_access!
+
+    ActionMailer::Base.deliveries.clear
+
+    post user_unlock_path, params: {
+      user: {
+        email: user.email
+      }
+    }
+
+    mail = ActionMailer::Base.deliveries.last
+
+    assert_not_nil mail
+    assert_includes mail.body.encoded, default_extranet.host
+  end
+end


### PR DESCRIPTION
… 

## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les mails de déblocage de compte sont à présent envoyés avec la bonne url quand on bloque le compte depuis un extranet
close #3568 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
