### PR TITLE
Host correct sur les mails de déblocage 2

### DIFF
--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -28,9 +28,7 @@ module User::WithAuthentication
     def self.find_for_authentication(warden_conditions)
       host = warden_conditions.delete(:host)
       user = where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
-      if user && host
-        user.registration_context = user.best_context(host) || user.university
-      end
+      user.set_registration_context_from_host(host) if user && host
       user
     end
 
@@ -73,7 +71,7 @@ module User::WithAuthentication
     end
 
     def send_new_otp(request, options = {})
-      self.registration_context = best_context(request.host) || university
+      set_registration_context_from_host(request.host)
       super
     end
 

--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -28,7 +28,8 @@ module User::WithAuthentication
     def self.find_for_authentication(warden_conditions)
       host = warden_conditions.delete(:host)
       user = where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
-      user.set_registration_context_from_host(host) if user && host
+      return nil unless user
+      user.set_registration_context_from_host(host)
       user
     end
 

--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -28,7 +28,7 @@ module User::WithAuthentication
     def self.find_for_authentication(warden_conditions)
       host = warden_conditions.delete(:host)
       user = where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
-      return nil unless user
+      return unless user
       user.set_registration_context_from_host(host)
       user
     end

--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -26,7 +26,14 @@ module User::WithAuthentication
     before_validation :adjust_mobile_phone, :sanitize_fields
 
     def self.find_for_authentication(warden_conditions)
-      where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
+      host = warden_conditions.delete(:host)
+      user = where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
+      if user && host
+        user.registration_context = Communication::Extranet.with_host(host) ||
+                                    University.with_host(host) ||
+                                    user.university
+      end
+      user
     end
 
     def self.send_reset_password_instructions(attributes = {})

--- a/app/models/user/with_authentication.rb
+++ b/app/models/user/with_authentication.rb
@@ -29,9 +29,7 @@ module User::WithAuthentication
       host = warden_conditions.delete(:host)
       user = where(email: warden_conditions[:email].downcase, university_id: warden_conditions[:university_id]).first
       if user && host
-        user.registration_context = Communication::Extranet.with_host(host) ||
-                                    University.with_host(host) ||
-                                    user.university
+        user.registration_context = user.best_context(host) || user.university
       end
       user
     end
@@ -75,10 +73,7 @@ module User::WithAuthentication
     end
 
     def send_new_otp(request, options = {})
-      current_extranet = Communication::Extranet.with_host(request.host)
-      current_university = University.with_host(request.host)
-      current_university ||= university
-      self.registration_context = current_extranet || current_university
+      self.registration_context = best_context(request.host) || university
       super
     end
 

--- a/app/models/user/with_registration_context.rb
+++ b/app/models/user/with_registration_context.rb
@@ -8,6 +8,10 @@ module User::WithRegistrationContext
 
     after_create :send_notification_to_admins, unless: -> { registration_context.is_a?(Communication::Extranet) }
 
+    def best_context(host)
+      Communication::Extranet.with_host(host) || University.with_host(host)
+    end
+
     private
 
     def extranet_access

--- a/app/models/user/with_registration_context.rb
+++ b/app/models/user/with_registration_context.rb
@@ -9,7 +9,13 @@ module User::WithRegistrationContext
     after_create :send_notification_to_admins, unless: -> { registration_context.is_a?(Communication::Extranet) }
 
     def set_registration_context_from_host(host)
-      self.registration_context = Communication::Extranet.with_host(host) || University.with_host(host) || university
+      if host.present?
+        self.registration_context = Communication::Extranet.with_host(host) || 
+                                    University.with_host(host) || 
+                                    university
+      else
+        self.registration_context = university
+      end
     end
 
     private

--- a/app/models/user/with_registration_context.rb
+++ b/app/models/user/with_registration_context.rb
@@ -8,8 +8,8 @@ module User::WithRegistrationContext
 
     after_create :send_notification_to_admins, unless: -> { registration_context.is_a?(Communication::Extranet) }
 
-    def best_context(host)
-      Communication::Extranet.with_host(host) || University.with_host(host)
+    def set_registration_context_from_host(host)
+      self.registration_context = Communication::Extranet.with_host(host) || University.with_host(host) || university
     end
 
     private

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module Osuny
     config.i18n.enforce_available_locales = false
     config.i18n.load_path += Dir["#{Rails.root.to_s}/config/locales/**/*.yml"]
 
-    config.internal_domains = ['@noesya.coop'].freeze
+    config.internal_domains = ['@noesya.coop', '@osuny.org'].freeze
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -53,7 +53,7 @@ Devise.setup do |config|
   # find_for_authentication method and considered in your model lookup. For instance,
   # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
   # The same considerations mentioned for authentication_keys also apply to request_keys.
-  # config.request_keys = []
+  config.request_keys = [:host]
 
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used

--- a/test/controllers/users/unlocks_controller_test.rb
+++ b/test/controllers/users/unlocks_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class Users::UnlocksControllerTest < ActionDispatch::IntegrationTest
+
+  def test_extranet_unlock_instructions_mail_uses_extranet_host
+    host! default_extranet.host
+    user = users(:alumnus)
+
+    # Premier test : vérifie le contenue du mail envoyé si on clique sur le lien "Déblocage" depuis l'extranet
+    user.lock_access!
+    assert user.access_locked?
+    
+    ActionMailer::Base.deliveries.clear
+    
+    post user_unlock_path, params: {
+      user: {
+        email: user.email
+      }
+    }
+
+    mail = ActionMailer::Base.deliveries.last
+    
+    assert_not_nil mail
+    assert_includes mail.body.encoded, default_extranet.host
+    
+    # Second test : vérifie le contenu du mail envoyé si on bloque le compte depuis l'extranet en faisant 3 mauvais essais
+    user.unlock_access!
+    refute user.access_locked?
+
+    ActionMailer::Base.deliveries.clear
+
+    3.times do
+      post user_session_path, params: {
+        user: {
+          email: user.email,
+          password: "wrong-password"
+        },
+        hashcash: ActiveHashcash::Stamp.mint(host).to_s
+      }
+    end
+
+    user.reload
+    assert user.access_locked?
+    
+    mail = ActionMailer::Base.deliveries.last
+
+    assert_not_nil mail
+    assert_includes mail.body.encoded, default_extranet.host
+  end
+end


### PR DESCRIPTION
… 

## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les mails de déblocage de compte sont à présent envoyés avec la bonne url quand on bloque le compte depuis un extranet
close #3568 

Version alternative et plus simple de #4070 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
