### PR TITLE
Ajustements des options du block jobs

### DIFF
--- a/app/models/communication/block/template/job.rb
+++ b/app/models/communication/block/template/job.rb
@@ -18,7 +18,7 @@ class Communication::Block::Template::Job < Communication::Block::Template::Base
   has_component :option_image,        :boolean, default: true
   has_component :option_subtitle,     :boolean, default: true
   has_component :option_categories,   :boolean, default: false
-  has_component :option_date,         :boolean, default: false
+  has_component :option_dates,        :boolean, default: false
   has_component :option_summary,      :boolean, default: true
 
   def category

--- a/app/views/admin/communication/blocks/templates/jobs/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/jobs/_edit.html.erb
@@ -40,8 +40,15 @@
 <%= osuny_small_panel t('admin.communication.blocks.components.layouts.label') do %>
   <%= block_component_edit block, :layout %>
   <%= osuny_label t('admin.communication.blocks.display_options.title') %>
-  <%= block_component_edit block, :option_image, label: Communication::Website::Jobboard::Job::Localization.human_attribute_name(:featured_image) %>
-  <%= block_component_edit block, :option_subtitle, label: Communication::Website::Jobboard::Job::Localization.human_attribute_name(:subtitle) %>
-  <%= block_component_edit block, :option_summary, label: t('admin.summary.label') %>
-  <%= block_component_edit block, :option_categories, label: Communication::Website::Jobboard::Job.human_attribute_name(:categories) %>
+  <div class="row">
+    <div class="col-sm-6">
+      <%= block_component_edit block, :option_image, label: Communication::Website::Jobboard::Job::Localization.human_attribute_name(:featured_image) %>
+      <%= block_component_edit block, :option_subtitle, label: Communication::Website::Jobboard::Job::Localization.human_attribute_name(:subtitle) %>
+      <%= block_component_edit block, :option_summary, label: t('admin.summary.label') %>
+    </div>
+    <div class="col-sm-6">
+      <%= block_component_edit block, :option_dates, label: Communication::Website::Jobboard::Job.human_attribute_name(:dates) %>
+      <%= block_component_edit block, :option_categories, label: Communication::Website::Jobboard::Job.human_attribute_name(:categories) %>
+    </div>
+  </div>
 <% end %>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
close #3886 


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

Actuellement 5 sites ont des blocs de ce type et sont donc concernés :
- https://qlio.iut.u-bordeaux.fr
- https://example.osuny.org
- https://l-inconnue.rocketchanson.osuny.site
- https://www.gaite-lyrique.net
- https://www.campusartmediterranee.fr