### PR TITLE
Réparation d'un trou dans la synchronisation

### DIFF
--- a/app/controllers/admin/communication/websites_controller.rb
+++ b/app/controllers/admin/communication/websites_controller.rb
@@ -64,7 +64,7 @@ class Admin::Communication::WebsitesController < Admin::Communication::Websites:
                           @jobs.any? &&
                           can?(:read, Communication::Website::Jobboard::Job)
     # Git files
-    @git_files_desynchronized = @website.git_files_desynchronized
+    @desynchronized_generated_git_files = @website.desynchronized_generated_git_files
     breadcrumb
   end
 

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -8,6 +8,7 @@
 #  current_sha       :string
 #  desynchronized    :boolean          default(TRUE)
 #  desynchronized_at :datetime         indexed
+#  generated_at      :datetime
 #  previous_path     :string
 #  previous_sha      :string
 #  created_at        :datetime         not null

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -82,11 +82,13 @@ class Communication::Website::GitFile < ApplicationRecord
 
   def mark_for_destruction!
     return if current_path.nil? && current_sha.nil?
+    now = Time.zone.now
     update(
       current_path: nil,
       current_sha: nil,
       desynchronized: true,
-      desynchronized_at: Time.zone.now
+      desynchronized_at: now,
+      generated_at: now
     )
   end
 
@@ -101,6 +103,10 @@ class Communication::Website::GitFile < ApplicationRecord
       desynchronized: false,
       desynchronized_at: nil
     )
+  end
+
+  def generated?
+    generated_at.present?
   end
 
   def to_s

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -41,6 +41,7 @@ class Communication::Website::GitFile < ApplicationRecord
   # One Git File per about and website, unless about is nil (destroy orphans)
   validates :about_id, uniqueness: { scope: [:about_type, :website_id] }, allow_nil: true
 
+  scope :generated, -> { where.not(generated_at: nil) }
   scope :desynchronized, -> { where(desynchronized: true) }
   scope :desynchronized_since, -> (time) { desynchronized.where('desynchronized_at > ?', time) }
   scope :desynchronized_until, -> (time) { desynchronized.where('desynchronized_at <= ?', time) }

--- a/app/models/communication/website/git_file/with_content.rb
+++ b/app/models/communication/website/git_file/with_content.rb
@@ -16,11 +16,13 @@ module Communication::Website::GitFile::WithContent
     return if up_to_date?
     @current_content = nil
     ActiveStorage::Utils.attach_from_text(current_content_file, computed_content, 'file.html')
+    now = Time.zone.now
     update(
       current_path: computed_path,
       current_sha: computed_sha,
       desynchronized: true,
-      desynchronized_at: Time.zone.now
+      desynchronized_at: now,
+      generated_at: now
     )
   end
 

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -50,7 +50,8 @@ module Communication::Website::WithGitRepository
 
   def sync_with_git_safely
     return unless git_repository.valid?
-    git_repository.git_files = git_files.desynchronized_until(last_sync_at)
+    git_repository.git_files = git_files.generated
+                                        .desynchronized_until(last_sync_at)
                                         .order(:desynchronized_at)
                                         .limit(git_repository.batch_size)
     git_repository.sync!
@@ -119,7 +120,9 @@ module Communication::Website::WithGitRepository
     Communication::Website::AnalyseJob.perform_later(id)
   end
 
-  def git_files_desynchronized
-    last_sync_at.nil? ? git_files.desynchronized : git_files.desynchronized_since(last_sync_at)
+  def desynchronized_generated_git_files
+    git_files_list = git_files.generated
+    last_sync_at.nil? ? git_files_list.desynchronized
+                      : git_files_list.desynchronized_since(last_sync_at)
   end
 end

--- a/app/services/git/analyzer.rb
+++ b/app/services/git/analyzer.rb
@@ -16,7 +16,7 @@ class Git::Analyzer
   end
 
   def should_destroy?
-    git_file.current_path.nil?
+    git_file.generated? && git_file.current_path.nil?
   end
 
   protected

--- a/app/services/git/analyzer.rb
+++ b/app/services/git/analyzer.rb
@@ -8,11 +8,11 @@ class Git::Analyzer
   end
 
   def should_create?
-    !should_destroy? && !exists?(git_file.current_path) && !moved?
+    git_file.generated? && !should_destroy? && !exists?(git_file.current_path) && !moved?
   end
 
   def should_update?
-    !should_destroy? && (moved? || different?)
+    git_file.generated? && !should_destroy? && (moved? || different?)
   end
 
   def should_destroy?

--- a/app/views/admin/communication/websites/show.html.erb
+++ b/app/views/admin/communication/websites/show.html.erb
@@ -2,17 +2,17 @@
 
 <% content_for :title_right do %>
   <%= render 'admin/application/favorites/widget', about: @website %>
-  <%= link_to t('open'), 
+  <%= link_to t('open'),
               @website.url,
               target: :_blank,
               class: button_classes if @website.url.present? %>
   <%= link_to t('communication.website.golive.button'),
               production_admin_communication_website_path(@website),
               class: button_classes unless @website.in_production %>
-  <% if can?(:synchronize, @website) && @git_files_desynchronized.any? %>
+  <% if can?(:synchronize, @website) && @desynchronized_generated_git_files.any? %>
     <%= link_to synchronize_admin_communication_website_path(@website), method: :post, class: button_classes do %>
       <%= t('admin.communication.website.synchronize.button') %>
-      <span class="badge rounded-pill border border-subtle text-dark"><%= @git_files_desynchronized.length %></span>
+      <span class="badge rounded-pill border border-subtle text-dark"><%= @desynchronized_generated_git_files.length %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/db/migrate/20260611153511_add_generated_at_to_communication_git_files.rb
+++ b/db/migrate/20260611153511_add_generated_at_to_communication_git_files.rb
@@ -1,0 +1,7 @@
+class AddGeneratedAtToCommunicationGitFiles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :communication_git_files, :generated_at, :datetime
+    Communication::Website::GitFile.reset_column_information
+    Communication::Website::GitFile.update_all(generated_at: Time.zone.now)
+  end
+end

--- a/db/migrate/20260611153511_add_generated_at_to_communication_git_files.rb
+++ b/db/migrate/20260611153511_add_generated_at_to_communication_git_files.rb
@@ -1,6 +1,6 @@
 class AddGeneratedAtToCommunicationGitFiles < ActiveRecord::Migration[8.1]
   def change
-    add_column :communication_git_files, :generated_at, :datetime
+    add_column :communication_website_git_files, :generated_at, :datetime
     Communication::Website::GitFile.reset_column_information
     Communication::Website::GitFile.update_all(generated_at: Time.zone.now)
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_153511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
   enable_extension "pgcrypto"
   enable_extension "unaccent"
 
-  create_table "action_text_rich_texts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "action_text_rich_texts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
     t.string "name", null: false
@@ -45,7 +45,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["ip_address", "created_at"], name: "index_active_hashcash_stamps_on_ip_address_and_created_at", where: "(ip_address IS NOT NULL)"
   end
 
-  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "deleted_at"
@@ -56,7 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "byte_size", null: false
     t.string "checksum"
     t.string "content_type"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_active_storage_blobs_on_university_id"
   end
 
-  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -127,7 +127,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["education_school_id", "administration_location_id"], name: "index_location_school"
   end
 
-  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
     t.text "name"
@@ -135,7 +135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "criterion_id", null: false
     t.text "glossary"
@@ -149,7 +149,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["criterion_id"], name: "index_administration_qualiopi_indicators_on_criterion_id"
   end
 
-  create_table "communication_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_blocks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.uuid "communication_website_id"
@@ -159,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.string "html_class"
     t.jsonb "metadata"
     t.string "migration_identifier"
+    t.boolean "native", default: false
     t.integer "position", null: false
     t.boolean "published", default: true
     t.integer "template_kind", default: 0, null: false
@@ -170,7 +171,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id", "template_kind"], name: "index_communication_blocks_on_university_id_and_template_kind"
   end
 
-  create_table "communication_extranet_connections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_connections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.datetime "created_at", null: false
@@ -182,7 +183,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_extranet_connections_on_university_id"
   end
 
-  create_table "communication_extranet_document_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_document_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
@@ -223,7 +224,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_0dc1259072"
   end
 
-  create_table "communication_extranet_document_kinds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_document_kinds", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
@@ -249,7 +250,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_95419f1df4"
   end
 
-  create_table "communication_extranet_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_documents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "category_id"
     t.datetime "created_at", null: false
     t.uuid "extranet_id", null: false
@@ -285,7 +286,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_extranet_localizations_on_university_id"
   end
 
-  create_table "communication_extranet_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_post_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "extranet_id", null: false
     t.uuid "university_id", null: false
@@ -332,7 +333,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_28188e2217"
   end
 
-  create_table "communication_extranet_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranet_posts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "author_id"
     t.uuid "category_id"
     t.datetime "created_at", null: false
@@ -345,7 +346,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_extranet_posts_on_university_id"
   end
 
-  create_table "communication_extranets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranets", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.string "color"
@@ -620,7 +621,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_bca328e63c"
   end
 
-  create_table "communication_website_agenda_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_agenda_events", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -811,7 +812,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_website_alerts_on_university_id"
   end
 
-  create_table "communication_website_connections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_connections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "direct_source_id"
     t.string "direct_source_type"
@@ -867,7 +868,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_website_git_file_orphans_on_university_id"
   end
 
-  create_table "communication_website_git_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_git_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.datetime "created_at", null: false
@@ -875,6 +876,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.string "current_sha"
     t.boolean "desynchronized", default: true
     t.datetime "desynchronized_at"
+    t.datetime "generated_at"
     t.string "previous_path"
     t.string "previous_sha"
     t.uuid "university_id"
@@ -1011,7 +1013,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_website_localizations_on_university_id"
   end
 
-  create_table "communication_website_menu_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menu_items", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.datetime "created_at", null: false
@@ -1034,7 +1036,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["website_id"], name: "index_communication_website_menu_items_on_website_id"
   end
 
-  create_table "communication_website_menus", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menus", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "automatic", default: true
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -1133,7 +1135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_e62b2aba53"
   end
 
-  create_table "communication_website_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_pages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -1154,7 +1156,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_communication_website_pages_on_university_id"
   end
 
-  create_table "communication_website_permalinks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_permalinks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.datetime "created_at", null: false
@@ -1267,7 +1269,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_ac2f4a0bfc"
   end
 
-  create_table "communication_website_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_post_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -1355,7 +1357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["unpublication_job_id"], name: "idx_on_unpublication_job_id"
   end
 
-  create_table "communication_website_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_posts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.uuid "communication_website_id", null: false
     t.datetime "created_at", null: false
@@ -1390,7 +1392,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["communication_website_showcase_tag_id", "communication_website_id"], name: "index_showcase_tag_website"
   end
 
-  create_table "communication_websites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_websites", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id"
     t.string "about_type"
     t.string "access_token"
@@ -1466,7 +1468,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_academic_year_localizations_on_university_id"
   end
 
-  create_table "education_academic_years", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_academic_years", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.uuid "university_id", null: false
@@ -1496,7 +1498,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_cohort_localizations_on_university_id"
   end
 
-  create_table "education_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_cohorts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "academic_year_id", null: false
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
@@ -1547,7 +1549,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_diploma_localizations_on_university_id"
   end
 
-  create_table "education_diplomas", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_diplomas", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "certification"
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
@@ -1646,7 +1648,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_program_localizations_on_university_id"
   end
 
-  create_table "education_programs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_programs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "apprenticeship"
     t.string "bodyclass"
     t.integer "capacity"
@@ -1700,7 +1702,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_school_localizations_on_university_id"
   end
 
-  create_table "education_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_schools", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address"
     t.string "city"
     t.string "country"
@@ -1715,7 +1717,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_education_schools_on_university_id"
   end
 
-  create_table "emergency_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "emergency_messages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "content_en"
     t.text "content_fr"
     t.datetime "created_at", null: false
@@ -1821,7 +1823,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
-  create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "imports", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "kind"
     t.uuid "language_id", null: false
@@ -1836,7 +1838,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 
-  create_table "languages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "languages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "iso_code"
     t.string "name"
@@ -1850,7 +1852,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id", "language_id"], name: "index_languages_universities_on_university_id_and_language_id"
   end
 
-  create_table "research_hal_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_hal_authors", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "docid"
     t.string "first_name"
@@ -1909,7 +1911,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_dc9f1267b7"
   end
 
-  create_table "research_journal_paper_kinds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_paper_kinds", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.uuid "journal_id", null: false
@@ -1941,7 +1943,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_research_journal_paper_localizations_on_university_id"
   end
 
-  create_table "research_journal_papers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_papers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.date "accepted_at"
     t.text "bibliography"
     t.datetime "created_at", null: false
@@ -1993,7 +1995,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_research_journal_volume_localizations_on_university_id"
   end
 
-  create_table "research_journal_volumes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_volumes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.integer "number"
@@ -2004,7 +2006,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_research_journal_volumes_on_university_id"
   end
 
-  create_table "research_journals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journals", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.uuid "university_id", null: false
@@ -2012,7 +2014,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_research_journals_on_university_id"
   end
 
-  create_table "research_laboratories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address"
     t.string "city"
     t.string "country"
@@ -2031,7 +2033,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_person_id", "research_laboratory_id"], name: "laboratory_person"
   end
 
-  create_table "research_laboratory_axes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratory_axes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.integer "position", null: false
@@ -2076,7 +2078,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_research_laboratory_localizations_on_university_id"
   end
 
-  create_table "research_publications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_publications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "abstract"
     t.text "anr_project_references", default: [], array: true
     t.json "authors_citeproc"
@@ -2110,7 +2112,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_person_id", "research_publication_id"], name: "index_publication_person"
   end
 
-  create_table "research_theses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_theses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "author_id", null: false
     t.boolean "completed", default: false
     t.date "completed_at"
@@ -2163,7 +2165,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["website_id"], name: "index_search_index_on_website_id"
   end
 
-  create_table "universities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "universities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address"
     t.boolean "admin_already_auto_promoted", default: false
     t.string "city"
@@ -2194,7 +2196,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["name"], name: "index_universities_on_name", opclass: :gin_trgm_ops, using: :gin
   end
 
-  create_table "university_apps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_apps", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
     t.string "token"
@@ -2205,7 +2207,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_apps_on_university_id"
   end
 
-  create_table "university_organization_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organization_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.datetime "created_at", null: false
     t.boolean "is_taxonomy", default: false
@@ -2219,7 +2221,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_organization_categories_on_university_id"
   end
 
-  create_table "university_organization_categories_organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organization_categories_organizations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "category_id", null: false
     t.uuid "organization_id", null: false
     t.index ["category_id"], name: "idx_on_category_id_7494b991ff"
@@ -2282,7 +2284,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_organization_localizations_on_university_id"
   end
 
-  create_table "university_organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organizations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address"
     t.string "bodyclass"
     t.string "city"
@@ -2291,6 +2293,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.uuid "created_by_id"
     t.datetime "deleted_at"
     t.string "email"
+    t.boolean "is_laboratory", default: false
+    t.boolean "is_location", default: false
+    t.boolean "is_school", default: false
     t.integer "kind", default: 10
     t.float "latitude"
     t.float "longitude"
@@ -2305,7 +2310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_organizations_on_university_id"
   end
 
-  create_table "university_people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_people", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address"
     t.integer "address_visibility", default: 0
     t.date "birthdate"
@@ -2343,14 +2348,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["user_id"], name: "index_university_people_on_user_id"
   end
 
-  create_table "university_people_person_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_people_person_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "category_id", null: false
     t.uuid "person_id", null: false
     t.index ["category_id"], name: "index_university_people_person_categories_on_category_id"
     t.index ["person_id"], name: "index_university_people_person_categories_on_person_id"
   end
 
-  create_table "university_person_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "bodyclass"
     t.datetime "created_at", null: false
     t.boolean "is_taxonomy", default: false
@@ -2402,7 +2407,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_1be9c668d5"
   end
 
-  create_table "university_person_experiences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_experiences", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.integer "from_year"
@@ -2430,7 +2435,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "idx_on_university_id_0b815cf13a"
   end
 
-  create_table "university_person_involvements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_involvements", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.integer "kind"
@@ -2489,7 +2494,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_role_localizations_on_university_id"
   end
 
-  create_table "university_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_roles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.integer "position", null: false
@@ -2501,7 +2506,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["university_id"], name: "index_university_roles_on_university_id"
   end
 
-  create_table "user_favorites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "user_favorites", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "about_id", null: false
     t.string "about_type", null: false
     t.datetime "created_at", null: false
@@ -2511,7 +2516,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_104055) do
     t.index ["user_id"], name: "index_user_favorites_on_user_id"
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.integer "brevo_contact_id"
     t.datetime "confirmation_sent_at", precision: nil
     t.string "confirmation_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,7 +159,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_153511) do
     t.string "html_class"
     t.jsonb "metadata"
     t.string "migration_identifier"
-    t.boolean "native", default: false
     t.integer "position", null: false
     t.boolean "published", default: true
     t.integer "template_kind", default: 0, null: false
@@ -2293,9 +2292,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_153511) do
     t.uuid "created_by_id"
     t.datetime "deleted_at"
     t.string "email"
-    t.boolean "is_laboratory", default: false
-    t.boolean "is_location", default: false
-    t.boolean "is_school", default: false
     t.integer "kind", default: 10
     t.float "latitude"
     t.float "longitude"

--- a/test/fixtures/communication/website/git_files.yml
+++ b/test/fixtures/communication/website/git_files.yml
@@ -10,6 +10,6 @@ git_file_2:
   about: test_post_2_fr (Communication::Website::Post::Localization)
   website: website_with_github
   university: default_university
+  generated_at: <%= Time.now - 1.hour %>
   desynchronized: true
-  desynchronized_at: Time.now - 1.hour
-  generated_at: Time.now - 1.hour
+  desynchronized_at: <%= Time.now - 1.hour %>

--- a/test/fixtures/communication/website/git_files.yml
+++ b/test/fixtures/communication/website/git_files.yml
@@ -12,3 +12,4 @@ git_file_2:
   university: default_university
   desynchronized: true
   desynchronized_at: Time.now - 1.hour
+  generated_at: Time.now - 1.hour


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fix #4095

Quand la synchronisation du site se fait avant la génération d'un `git_file`, le `git_file` est supprimé. Ce comportement est incorrect, on le résout en vérifiant l'état de génération.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [x] Incidence forte 😱
