### PR TITLE
Bump Hugo version to 0.161.1

### DIFF
--- a/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
+++ b/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
@@ -30,7 +30,7 @@ jobs:
     - name: Installation de Hugo
       uses: noesya/actions-hugo@release
       with:
-        hugo-version: '0.159.2'
+        hugo-version: '0.161.1'
         extended: true
 
     - name: Compilation du site

--- a/app/views/admin/communication/websites/configs/netlify_config/static.html.erb
+++ b/app/views/admin/communication/websites/configs/netlify_config/static.html.erb
@@ -3,7 +3,7 @@
   command = "yarn osuny build"
 
 [build.environment]
-  HUGO_VERSION = "0.159.2"
+  HUGO_VERSION = "0.161.1"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Bump de la version d'Hugo vers 0.161.1 pour les sites Deuxfleurs et Netlify

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
