### PR TITLE
Correction de la création de bloc orga alphabétique avec des éléments dedans

### DIFF
--- a/app/models/communication/block/template/base/with_data.rb
+++ b/app/models/communication/block/template/base/with_data.rb
@@ -19,7 +19,7 @@ module Communication::Block::Template::Base::WithData
     end
     if has_element_class?
       hash['elements'] = []
-      elements.each do |element|
+      @elements.each do |element|
         hash['elements'] << element.data
       end
     end


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fix #4123 

En gros, le getter de `template.data` passe par la variable `@elements` et non plus la méthode `elements` qui est override pour certains blocs.

Cela permet en passant de garder l'ordre en DB dans le formulaire du bloc (qui passe par `template.data.elements`) tout en conservant l'ordre alpha dans les static et les snippets (qui passent par `template.elements`)

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
