### PR TITLE
Log des tâches en cours toutes les 2mn

### DIFF
--- a/app/models/tasks_count.rb
+++ b/app/models/tasks_count.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: tasks_counts
+#
+#  id            :bigint           not null, primary key
+#  tasks_pending :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+class TasksCount < ApplicationRecord
+  validates :tasks_pending, presence: true, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/cron.json
+++ b/cron.json
@@ -15,6 +15,10 @@
     {
       "command": "*/10 * * * * rails auto:synchronize_websites",
       "size": "S"
+    },
+    {
+      "command": "*/2 * * * * rails auto:log_tasks_count",
+      "size": "S"
     }
   ]
 }

--- a/db/migrate/20260618144210_create_tasks_count.rb
+++ b/db/migrate/20260618144210_create_tasks_count.rb
@@ -1,0 +1,8 @@
+class CreateTasksCount < ActiveRecord::Migration[8.1]
+  def change
+    create_table :tasks_counts do |t|
+      t.integer :tasks_pending, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_144210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -2163,6 +2163,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
     t.index ["language_id"], name: "index_search_index_on_language_id"
     t.index ["university_id"], name: "index_search_index_on_university_id"
     t.index ["website_id"], name: "index_search_index_on_website_id"
+  end
+
+  create_table "tasks_counts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "tasks_pending", default: 0, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "universities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/auto.rake
+++ b/lib/tasks/auto.rake
@@ -35,4 +35,13 @@ namespace :auto do
     ActiveRecord::Base.connection.execute('REINDEX TABLE good_jobs')
     ActiveRecord::Base.connection.execute('REINDEX TABLE good_job_executions')
   end
+
+  desc 'Log pending tasks count'
+  task log_tasks_count: :environment do
+    count = GoodJob::Job.where(scheduled_at: ..Time.current)
+                        .where(finished_at: nil)
+                        .count
+    TasksCount.create!(tasks_pending: count)
+    TasksCount.where('created_at < ?', 3.months.ago).delete_all
+  end
 end


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
J'ajoute un système pour stocker toutes les 2mn le nombre de tâches en attente.
Je garde 3 mois d'archives.
Dans un second temps je ferai une interface de dataviz


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
