### PR TITLE
Ajout d'une couleur selon le nombre de tâches en cours

### DIFF
--- a/app/helpers/admin/tasks_helper.rb
+++ b/app/helpers/admin/tasks_helper.rb
@@ -1,0 +1,16 @@
+module Admin::TasksHelper
+
+  WARNING_THRESHOLD = 1000
+  ALERT_THRESHOLD = 2000
+
+  def background_tasks_counter_color(number_of_tasks)
+    if number_of_tasks >= ALERT_THRESHOLD
+      return 'text-danger' 
+    elsif number_of_tasks >= WARNING_THRESHOLD
+      return 'text-warning'
+    else
+      return 'text-white'
+    end
+  end
+
+end

--- a/app/views/admin/application/components/_footer.html.erb
+++ b/app/views/admin/application/components/_footer.html.erb
@@ -2,8 +2,9 @@
   <div class="container-fluid">
     <div class="row my-5 pb-5">
       <div class="offset-lg-1 col-lg-5 pb-4 backgroundTasks__count">
-        <p class="<%= background_tasks_counter_color(background_tasks_count) %>"><%= t('admin.pending_tasks.tasks') %></p>
-        <div class="display-5 text-serif"><%= link_to background_tasks_count, admin_tasks_count_path, class: background_tasks_counter_color(background_tasks_count) %></div>
+        <% color_class = background_tasks_counter_color(background_tasks_count) %>
+        <p class="<%= color_class %>"><%= t('admin.pending_tasks.tasks') %></p>
+        <div class="display-5 text-serif"><%= link_to background_tasks_count, admin_tasks_count_path, class: color_class %></div>
       </div>
       <div class="col-lg-5 pb-4">
         <p class="text-white-50 text-uppercase"><%= t('admin.pending_tasks.what_is_it') %></p>

--- a/app/views/admin/application/components/_footer.html.erb
+++ b/app/views/admin/application/components/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="container-fluid">
     <div class="row my-5 pb-5">
       <div class="offset-lg-1 col-lg-5 pb-4 backgroundTasks__count">
-        <p class="text-white"><%= t('admin.pending_tasks.tasks') %></p>
-        <div class="display-5 text-serif"><%= link_to background_tasks_count, admin_tasks_count_path %></div>
+        <p class="<%= background_tasks_counter_color(background_tasks_count) %>"><%= t('admin.pending_tasks.tasks') %></p>
+        <div class="display-5 text-serif"><%= link_to background_tasks_count, admin_tasks_count_path, class: background_tasks_counter_color(background_tasks_count) %></div>
       </div>
       <div class="col-lg-5 pb-4">
         <p class="text-white-50 text-uppercase"><%= t('admin.pending_tasks.what_is_it') %></p>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
Le compteur de tâches du footer prend une jolie couleur orangée ou rouge lorsqu'on grimpe à trop de tâches


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
