### PR TITLE
Donne l'accès aux listes de git_files pour les admin et les website_manager

### DIFF
--- a/app/models/ability/admin.rb
+++ b/app/models/ability/admin.rb
@@ -83,6 +83,7 @@ class Ability::Admin < Ability
     can :manage, Communication::Media, university_id: @user.university_id
     can :manage, Communication::Media::Category, university_id: @user.university_id
     can :manage, Communication::Media::Collection, university_id: @user.university_id
+    can :read, Communication::Website::GitFile, university_id: @user.university_id
   end
 
   def admin_communication_extranet

--- a/app/models/ability/website_manager.rb
+++ b/app/models/ability/website_manager.rb
@@ -32,6 +32,8 @@ class Ability::WebsiteManager < Ability
     can :manage, Communication::Media::Category, university_id: @user.university_id
     can :manage, Communication::Media::Collection, university_id: @user.university_id
     cannot :destroy, Communication::Website
+    can :read, Communication::Website::GitFile, university_id: @user.university_id, website_id: managed_websites_ids
+
   end
 
   protected


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Les "admin" et les "website_manager" peuvent à présent accéder à la liste de git_files de leurs sites web
close #4121 


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
