### PR TITLE
Correction de création d'événement enfant en rajoutant le parent actuel

### DIFF
--- a/app/models/communication/website/agenda/event/with_kinds.rb
+++ b/app/models/communication/website/agenda/event/with_kinds.rb
@@ -79,7 +79,7 @@ module Communication::Website::Agenda::Event::WithKinds
     # parent can be set only if there's at least a good candidate
     possible_parents.any? &&
     (
-      can_change_parent? || 
+      can_change_parent? ||
       can_become_child?
     )
   end
@@ -89,6 +89,7 @@ module Communication::Website::Agenda::Event::WithKinds
                                  .who_can_have_children
                                  .current_on(from_day)
                                  .where.not(id: id)
+                                 .or(website.events.where(id: parent_id))
   end
 
   protected
@@ -101,7 +102,7 @@ module Communication::Website::Agenda::Event::WithKinds
     # because events can become children
     parent.nil? &&
     # but only same day events, as multi-days events splits children by day
-    single_day? && 
+    single_day? &&
     # and never children of children
     !kind_parent?
   end

--- a/app/views/admin/communication/websites/agenda/events/_form.html.erb
+++ b/app/views/admin/communication/websites/agenda/events/_form.html.erb
@@ -91,7 +91,7 @@
                             collection: osuny_collection(
                               @event.possible_parents,
                               localized: true
-                            ) if event.can_set_parent?  %>
+                            ) if event.can_set_parent? %>
           <%= f.input :bodyclass, label: t('admin.bodyclass') %>
         <% end %>
         <%= render 'admin/communication/websites/federations/form', f: f %>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction de création d'événement enfant en rajoutant le parent actuel

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
