### PR TITLE
API > Correction du changement de la featured image quand c'est l'unique changement

### DIFF
--- a/app/controllers/api/osuny/application_controller/with_resource_params.rb
+++ b/app/controllers/api/osuny/application_controller/with_resource_params.rb
@@ -45,6 +45,8 @@ module Api::Osuny::ApplicationController::WithResourceParams
     end
     # Set the image URL so that the object can delay the upload if needed
     l10n_params[:featured_image_new_url] = featured_image_data[:url]
+    # We also force the updated_at to change, as changing on the featured_image does not trigger the save
+    l10n_params[:updated_at] = Time.current
   end
 
   def set_blocks_attributes_to_l10n_params(l10n_params, l10n: nil)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Quand le `featured_image_new_url` était le seul changement, le save n'était pas trigger (donc le job de changement d'image non enqueued) car aucun changement d'attributs en DB n'était détecté

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
