### PR TITLE
Réparation des blocs de pied de page

### DIFF
--- a/app/models/communication/website/localization.rb
+++ b/app/models/communication/website/localization.rb
@@ -81,6 +81,10 @@ class Communication::Website::Localization < ApplicationRecord
     [default_shared_image&.blob]
   end
 
+  def communication_website_id
+    about_id
+  end
+
   def to_s
     name
   end

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -1,7 +1,13 @@
 namespace :app do
   desc 'Fix things'
   task fix: :environment do
-    # Nothing for now
+    Communication::Block.where(
+      communication_website_id: nil,
+      about_type: "Communication::Website::Localization"
+    ).each do |block|
+      block.update_column :communication_website_id,
+                          block.about.communication_website_id
+    end
   end
 
   namespace :search do


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les blocs de footer n'étaient pas connectés au website car ils se basaient sur `about.try(:communication_website_id)`, or les `Communication::Website::Localization` ne répondaient pas à cette méthode. C'est chose faite

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
