### PR TITLE
Serveur SMTP personnalisable, services tiers optionnels et emails en dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :development do
   gem "annotaterb"
   gem "better_errors"
   gem "binding_of_caller"
+  gem "letter_opener_web"
   gem "listen", "~> 3.10"
   gem "rack-mini-profiler", "~> 4.0"
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,8 @@ GEM
       caxlsx (>= 4.0)
     cgi (0.5.2)
     chartkick (5.2.1)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     citeproc (1.1.0)
       date
       forwardable
@@ -420,9 +422,20 @@ GEM
     kaminari-core (1.2.2)
     languagetool-widget (8.3.4)
       rails
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
     leaflet-rails (1.9.5)
       actionpack (>= 4.2.0)
       railties (>= 4.2.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     libretranslate (0.1.0)
       json
       net-http
@@ -831,6 +844,7 @@ DEPENDENCIES
   kaminari
   languagetool-widget
   leaflet-rails
+  letter_opener_web
   libretranslate
   listen (~> 3.10)
   lucide-rails

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -18,8 +18,4 @@ class ApplicationMailer < ActionMailer::Base
     opts[:from] = opts[:reply_to] = university.mail_from[:full]
     opts
   end
-
-  def should_send?(email)
-    Rails.env.production? || Rails.env.development? || email.end_with?(*Rails.application.config.internal_domains)
-  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -20,6 +20,6 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def should_send?(email)
-    Rails.env.production? || email.end_with?(*Rails.application.config.internal_domains)
+    Rails.env.production? || Rails.env.development? || email.end_with?(*Rails.application.config.internal_domains)
   end
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -70,7 +70,7 @@ class DeviseMailer < Devise::Mailer
   end
 
   def should_send?(email)
-    Rails.env.production? || email.end_with?(*Rails.application.config.internal_domains)
+    Rails.env.production? || Rails.env.development? || email.end_with?(*Rails.application.config.internal_domains)
   end
 
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -7,7 +7,7 @@ class DeviseMailer < Devise::Mailer
     @record = record
     opts = merge_with_university_infos(record.university, opts)
     I18n.with_locale(record.language.iso_code.to_sym) do
-      super if should_send?(record.email)
+      super
     end
   end
 
@@ -15,7 +15,7 @@ class DeviseMailer < Devise::Mailer
     @record = record
     opts = merge_with_university_infos(record.university, opts)
     I18n.with_locale(record.language.iso_code.to_sym) do
-      super if should_send?(record.email)
+      super
     end
   end
 
@@ -23,7 +23,7 @@ class DeviseMailer < Devise::Mailer
     @record = record
     opts = merge_with_university_infos(record.university, opts)
     I18n.with_locale(record.language.iso_code.to_sym) do
-      super if should_send?(record.email)
+      super
     end
   end
 
@@ -31,7 +31,7 @@ class DeviseMailer < Devise::Mailer
     @record = record
     opts = merge_with_university_infos(record.university, opts)
     I18n.with_locale(record.language.iso_code.to_sym) do
-      super if should_send?(record.email)
+      super
     end
   end
 
@@ -39,7 +39,7 @@ class DeviseMailer < Devise::Mailer
     @record = record
     opts = merge_with_university_infos(record.university, opts)
     I18n.with_locale(record.language.iso_code.to_sym) do
-      super if should_send?(record.email)
+      super
     end
   end
 
@@ -49,7 +49,7 @@ class DeviseMailer < Devise::Mailer
     @code = code
     @duration =  ActiveSupport::Duration.build(Rails.application.config.devise.direct_otp_valid_for).inspect
     I18n.with_locale(record.language.iso_code.to_sym) do
-      devise_mail(record, :two_factor_authentication_code, opts) if should_send?(record.email)
+      devise_mail(record, :two_factor_authentication_code, opts)
     end
   end
 
@@ -67,10 +67,6 @@ class DeviseMailer < Devise::Mailer
     opts[:host] = university.host
     opts[:from] = opts[:reply_to] = university.mail_from[:full]
     opts
-  end
-
-  def should_send?(email)
-    Rails.env.production? || Rails.env.development? || email.end_with?(*Rails.application.config.internal_domains)
   end
 
 end

--- a/app/mailers/extranet_mailer.rb
+++ b/app/mailers/extranet_mailer.rb
@@ -17,7 +17,7 @@ class ExtranetMailer < ApplicationMailer
     I18n.with_locale(@language.iso_code.to_sym) do
       mail  from: @university.mail_from[:full],
             to: @email,
-            subject: @l10n.invitation_message_subject if should_send?(@email)
+            subject: @l10n.invitation_message_subject
     end
   end
 

--- a/app/mailers/group_notification_mailer.rb
+++ b/app/mailers/group_notification_mailer.rb
@@ -9,9 +9,9 @@ class GroupNotificationMailer < ApplicationMailer
       subject = t('mailers.notifications.low_sms_credits.subject', credits: @credits)
       mail(
         from: university.mail_from[:full],
-        bcc: whitelisted_mails,
+        bcc: server_admin_emails,
         subject: subject
-      ) if whitelisted_mails.any?
+      ) if server_admin_emails.any?
     end
   end
 
@@ -22,22 +22,18 @@ class GroupNotificationMailer < ApplicationMailer
       subject = t('mailers.notifications.new_registration.subject', mail: @user.email)
       mail(
         from: university.mail_from[:full],
-        bcc: whitelisted_mails,
+        bcc: server_admin_emails,
         subject: subject
-      ) if whitelisted_mails.any?
+      ) if server_admin_emails.any?
     end
   end
 
   protected
 
-  def whitelisted_mails
-    @whitelisted_mails ||= users_emails.select { |mail| should_send?(mail) }
-  end
-
-  def users_emails
-    admin_users = @university.users.where(role: [:server_admin, :admin])
-    admin_users = admin_users.where.not(id: @user.id) if @user
-    admin_users.pluck(:email)
+  def server_admin_emails
+    @university.users
+               .where(role: [:server_admin])
+               .pluck(:email)
   end
 
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -13,7 +13,7 @@ class NotificationMailer < ApplicationMailer
         from: import.university.mail_from[:full],
         to: import.user.email,
         subject: subject
-      ) if should_send?(import.user.email)
+      )
     end
   end
 
@@ -26,7 +26,7 @@ class NotificationMailer < ApplicationMailer
         from: user.university.mail_from[:full],
         to: user.email,
         subject: subject
-      ) if should_send?(user.email)
+      )
     end
   end
 
@@ -40,7 +40,7 @@ class NotificationMailer < ApplicationMailer
         from: user.university.mail_from[:full],
         to: user.email,
         subject: subject
-      ) if should_send?(user.email)
+      )
     end
   end
 
@@ -52,7 +52,7 @@ class NotificationMailer < ApplicationMailer
         from: university.mail_from[:full],
         to: user.email,
         subject: subject
-      ) if should_send?(user.email)
+      )
     end
   end
 

--- a/app/services/brevo/contact_service.rb
+++ b/app/services/brevo/contact_service.rb
@@ -2,10 +2,12 @@ module Brevo
   class ContactService
 
     def self.sync(user)
+      return if ENV['BREVO_API_KEY'].blank?
       new(user).sync
     end
 
     def self.destroy(contact_id, university_id)
+      return if ENV['BREVO_API_KEY'].blank?
       api_instance = Brevo::ContactsApi.new
       other_user = User.where(brevo_contact_id: contact_id).first
 

--- a/app/services/brevo/contact_service.rb
+++ b/app/services/brevo/contact_service.rb
@@ -2,12 +2,12 @@ module Brevo
   class ContactService
 
     def self.sync(user)
-      return if ENV['BREVO_API_KEY'].blank?
+      return unless Brevo.active?
       new(user).sync
     end
 
     def self.destroy(contact_id, university_id)
-      return if ENV['BREVO_API_KEY'].blank?
+      return unless Brevo.active?
       api_instance = Brevo::ContactsApi.new
       other_user = User.where(brevo_contact_id: contact_id).first
 

--- a/app/services/brevo/sms_service.rb
+++ b/app/services/brevo/sms_service.rb
@@ -4,7 +4,7 @@ module Brevo
     SMS_CREDITS_LIMIT = 500
 
     def self.send_mfa_code(user, code)
-      return if ENV['BREVO_API_KEY'].blank?
+      return unless Brevo.active?
       duration =  ActiveSupport::Duration.build(Rails.application.config.devise.direct_otp_valid_for).inspect
       context = user.registration_context.respond_to?(:to_s_in) ? user.registration_context.to_s_in(user.language)
                                                                 : user.registration_context.to_s
@@ -13,7 +13,7 @@ module Brevo
     end
 
     def sms_credits
-      return if ENV['BREVO_API_KEY'].blank?
+      return unless Brevo.active?
       @sms_credits ||= plan.detect { |plan| plan.type == 'sms' }&.credits
     end
 

--- a/app/services/brevo/sms_service.rb
+++ b/app/services/brevo/sms_service.rb
@@ -4,6 +4,7 @@ module Brevo
     SMS_CREDITS_LIMIT = 500
 
     def self.send_mfa_code(user, code)
+      return if ENV['BREVO_API_KEY'].blank?
       duration =  ActiveSupport::Duration.build(Rails.application.config.devise.direct_otp_valid_for).inspect
       context = user.registration_context.respond_to?(:to_s_in) ? user.registration_context.to_s_in(user.language)
                                                                 : user.registration_context.to_s
@@ -12,6 +13,7 @@ module Brevo
     end
 
     def sms_credits
+      return if ENV['BREVO_API_KEY'].blank?
       @sms_credits ||= plan.detect { |plan| plan.type == 'sms' }&.credits
     end
 

--- a/app/views/application/_bugsnag.html.erb
+++ b/app/views/application/_bugsnag.html.erb
@@ -1,4 +1,4 @@
-<% unless Rails.env.development? %>
+<% unless Rails.env.development? || ENV['BUGSNAG_JAVASCRIPT_KEY'].blank? %>
   <script src="//d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js"></script>
   <script type="text/javascript" nonce="<%= request.content_security_policy_nonce %>">
     Bugsnag.start({

--- a/app/views/application/_bugsnag.html.erb
+++ b/app/views/application/_bugsnag.html.erb
@@ -1,4 +1,4 @@
-<% unless Rails.env.development? || ENV['BUGSNAG_JAVASCRIPT_KEY'].blank? %>
+<% if ENV['BUGSNAG_JAVASCRIPT_KEY'].present? && !Rails.env.development? %>
   <script src="//d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js"></script>
   <script type="text/javascript" nonce="<%= request.content_security_policy_nonce %>">
     Bugsnag.start({

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,11 +53,11 @@ module Osuny
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-        address: "smtp-relay.brevo.com",
-        port: 587,
+        address: ENV['SMTP_ADDRESS'].presence || "smtp-relay.brevo.com",
+        port: ENV['SMTP_PORT'].presence&.to_i || 587,
         user_name: ENV['SMTP_USER'],
         password: ENV['SMTP_PASSWORD'],
-        authentication: :plain
+        authentication: ENV['SMTP_AUTHENTICATION'].presence&.to_sym || :plain
     }
 
     # Need for +repage, because of https://github.com/rails/rails/commit/b2ab8dd3a4a184f3115e72b55c237c7b66405bd9

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,8 +49,6 @@ module Osuny
     config.i18n.enforce_available_locales = false
     config.i18n.load_path += Dir["#{Rails.root.to_s}/config/locales/**/*.yml"]
 
-    config.internal_domains = ['@noesya.coop', '@osuny.org'].freeze
-
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
         address: ENV['SMTP_ADDRESS'].presence || "smtp-relay.brevo.com",

--- a/config/application.sample.yml
+++ b/config/application.sample.yml
@@ -60,6 +60,10 @@ SECRET_KEY_BASE:
 
 SKYLIGHT_AUTHENTICATION:
 
+# If not provided, fallback to smtp-relay.brevo.com / 587 / plain
+SMTP_ADDRESS:
+SMTP_PORT:
+SMTP_AUTHENTICATION:
 SMTP_PASSWORD:
 SMTP_USER:
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,9 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Intercept emails and display them in the browser at /letter_opener
+  config.action_mailer.delivery_method = :letter_opener_web
+
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/brevo.rb
+++ b/config/initializers/brevo.rb
@@ -1,3 +1,5 @@
+return if ENV['BREVO_API_KEY'].blank?
+
 # Load the gem
 require 'brevo'
 

--- a/config/initializers/brevo.rb
+++ b/config/initializers/brevo.rb
@@ -1,12 +1,13 @@
-return if ENV['BREVO_API_KEY'].blank?
-
-# Load the gem
-require 'brevo'
-
 # Setup authorization
 Brevo.configure do |config|
   config.api_key['api-key'] = ENV['BREVO_API_KEY']
   config.api_key['partner-key'] = ENV['BREVO_API_KEY']
+end if ENV['BREVO_API_KEY'].present?
+
+Brevo.class_eval do
+  def self.active?
+    ENV['BREVO_API_KEY'].present?
+  end
 end
 
 api_instance = Brevo::AccountApi.new

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,5 @@
+return if ENV['BUGSNAG_RUBY_KEY'].blank?
+
 Bugsnag.configure do |config|
   config.api_key = ENV['BUGSNAG_RUBY_KEY']
   config.release_stage = ENV['APPLICATION_ENV']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   draw 'showcase'
   constraints host: ENV['OSUNY_TRANSPARENCY'] do
     get '/' => 'transparency/home#index'


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

L'objectif de cette PR est de permettre la personnalisation du serveur SMTP, de ne charger les services tiers Brevo (CRM) et Bugsnag que si les variables d'environnement sont définies/non vides et d'ajouter [Letter Opener](https://github.com/fgrehm/letter_opener_web) en environnement de développement.

----

Pour le serveur SMTP, on conserve `smtp-relay.brevo.com` / `587` / `plain` en paramètres par défaut si les variables d'environnement  `SMTP_ADDRESS`, `SMTP_PORT` et `SMTP_AUTHENTICATION` ne sont pas déclarées pour rester compatible avec l'existant.

Pour [Letter Opener](https://github.com/fgrehm/letter_opener_web), il permet de consulter directement l'ensemble des emails qui auraient normalement été transmis au serveur SMTP directement depuis le navigateur à l'adresse `/letter_opener`. Cela permet donc de s'affranchir d'une config valide de serveur SMTP en développement et permet de déboguer les emails sans risque d'envoi à de vraies personnes en cas de récupération des données depuis un autre environnement comme la production en environnement de développement puisque tout est "attrapé" par Letter Opener. La configuration des `internal_domains` reste en place pour les environnements annexes (pas `production` ni `development`, par exemple `staging`).

<img width="1224" height="804" alt="Capture d&#39;écran_20260715_094108" src="https://github.com/user-attachments/assets/1d8fea54-0476-4ce8-9685-3a2db12dac08" />

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
