### PR TITLE
Correction du nom de la langue originale sur le reset des blocs

### DIFF
--- a/app/views/admin/communication/blocks/group/editor/_reset.html.erb
+++ b/app/views/admin/communication/blocks/group/editor/_reset.html.erb
@@ -1,12 +1,12 @@
 <%
 if about.resetable_blocks?
-  original_language = about.original.language.to_s.downcase
+  original_language_name = language_name(about.original.language.iso_code)
   %>
   <div class="vue__blocks-editor__actions row mt-5 mb-4">
     <div class="offset-lg-4 col-lg-8 col-xxl-6">
-      <%= link_to t('admin.communication.contents.blocks.reset', language: original_language),
+      <%= link_to t('admin.communication.contents.blocks.reset', language: original_language_name),
                   reset_admin_communication_group_blocks_path(
-                    about_id: about.id, 
+                    about_id: about.id,
                     about_type: about.class.polymorphic_name
                   ),
                   method: :post,


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

### Avant

<img width="479" height="137" alt="image" src="https://github.com/user-attachments/assets/8623a61f-bf0f-47f1-b23b-aa9a67348702" />

### Après

<img width="400" height="99" alt="image" src="https://github.com/user-attachments/assets/1cd0dbfa-a7d3-45ca-87f7-01a5c5d0e6f5" />

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
