### PR TITLE
Remplacement de mark_for_update! par la méthode analyze! existante

### DIFF
--- a/app/controllers/admin/communication/blocks_controller.rb
+++ b/app/controllers/admin/communication/blocks_controller.rb
@@ -13,7 +13,7 @@ class Admin::Communication::BlocksController < Admin::Communication::Application
       block.update_column(:position, index + 1)
       about ||= block.about # Always the same about, doesn't matter
     end
-    about.try(:mark_git_files_for_update!)
+    about.try(:analyze_git_files!)
   end
 
   def new

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -83,8 +83,7 @@ class Communication::Website::GitFile < ApplicationRecord
   def mark_for_update!
     update(
       desynchronized: true,
-      desynchronized_at: Time.zone.now,
-      current_sha: nil
+      desynchronized_at: Time.zone.now
     )
   end
 

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -83,7 +83,8 @@ class Communication::Website::GitFile < ApplicationRecord
   def mark_for_update!
     update(
       desynchronized: true,
-      desynchronized_at: Time.zone.now
+      desynchronized_at: Time.zone.now,
+      current_sha: nil
     )
   end
 

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -80,13 +80,6 @@ class Communication::Website::GitFile < ApplicationRecord
     end
   end
 
-  def mark_for_update!
-    update(
-      desynchronized: true,
-      desynchronized_at: Time.zone.now
-    )
-  end
-
   def mark_for_destruction!
     return if current_path.nil? && current_sha.nil?
     now = Time.zone.now

--- a/app/models/communication/website/menu.rb
+++ b/app/models/communication/website/menu.rb
@@ -61,7 +61,9 @@ class Communication::Website::Menu < ApplicationRecord
   end
 
   def should_sync_to?(website)
-    website.id == communication_website_id && website.active_language_ids.include?(language_id) && items.any?
+    website.id == communication_website_id && 
+    website.active_language_ids.include?(language_id) &&
+    items.any?
   end
 
   def template_static

--- a/app/models/concerns/has_git_files.rb
+++ b/app/models/concerns/has_git_files.rb
@@ -30,8 +30,8 @@ module HasGitFiles
     path
   end
 
-  def mark_git_files_for_update!
-    git_files.each &:mark_for_update!
+  def analyze_git_files!
+    git_files.each &:analyze!
   end
 
 end


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fix #4202

Le problème se produit dans le reorder de blocks :
1. reorder
2. mark_git_files_for_update!
3. mark_for_update!

On enlève ce flux clandestin pour se rebrancher au flux de base des GitFile (à partir de `GitFile#analyze!`)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
