### PR TITLE
Gitlab: Envoi du body en JSON par défaut

### DIFF
--- a/config/initializers/gitlab.rb
+++ b/config/initializers/gitlab.rb
@@ -1,0 +1,3 @@
+Gitlab.configure do |config|
+  config.body_as_json = true  # use application/json for all requests with a body, default: false
+end


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Gitlab: Envoi du body en JSON par défaut

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
