### PR TITLE
Fix NoMethodError when validating a child event with no start date

### DIFF
--- a/app/models/communication/website/agenda/event/with_kinds.rb
+++ b/app/models/communication/website/agenda/event/with_kinds.rb
@@ -120,6 +120,8 @@ module Communication::Website::Agenda::Event::WithKinds
   end
 
   def in_parent_dates?
+    return if from_day.nil? || to_day.nil?
+
     if from_day < parent.from_day || to_day > parent.to_day
       errors.add(:parent_id, :outside_parent_dates)
     end

--- a/test/models/communication/website/agenda/event_test.rb
+++ b/test/models/communication/website/agenda/event_test.rb
@@ -81,6 +81,21 @@ class Communication::Website::Agenda::EventTest < ActiveSupport::TestCase
     assert_nothing_raised { event_l10n.cal }
   end
 
+  test "child event with a missing start date is invalid, not a crash" do
+    parent = new_event(
+      from_day: Date.tomorrow,
+      to_day: Date.tomorrow + 2.days
+    )
+    parent.save!
+
+    child = new_event(
+      from_day: nil,
+      parent: parent
+    )
+    assert_nothing_raised { child.valid? }
+    assert_not(child.valid?)
+  end
+
   protected
 
   def new_event(**options)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Fixes #4189.

When a child event is submitted without a start date, `in_parent_dates?` runs `from_day < parent.from_day` and raises `NoMethodError: undefined method '<' for nil` instead of returning a validation error. `from_day` already has a `presence: true` validation, so the missing date is reported anyway once this comparison stops crashing. This guards `in_parent_dates?` to skip the range check when `from_day` or `to_day` is nil, matching how the SQL-based `no_child_before?`/`no_child_after?` siblings already tolerate nil.

Added a model test for a child event with no start date. It needs the full Rails/Postgres test harness to run, which I could not stand up locally, but it mirrors the existing `event_test.rb` cases.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
