### PR TITLE
Invalider le token Gitlab quand le serveur retourne Gitlab::Error::Forbidden

### DIFF
--- a/app/services/git/providers/gitlab.rb
+++ b/app/services/git/providers/gitlab.rb
@@ -91,7 +91,7 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
     begin
       client.project(repository)
       true
-    rescue Gitlab::Error::Unauthorized
+    rescue Gitlab::Error::Unauthorized, Gitlab::Error::Forbidden
       git_repository.website.invalidate_access_token!
       false
     end


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Invalidate Gitlab token when server returns Gitlab::Error::Forbidden

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
