### PR TITLE
Génération de slugs avec des caractères non-latins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "active_hashcash"
 gem "active_storage_validations", "~> 1"
 gem "add_to_calendar"
 gem "aws-sdk-s3"
+gem "babosa", "~> 2.1"
 gem "bootstrap"
 gem "bootsnap", "~> 1", require: false
 gem "bootstrap5-kaminari-views"
@@ -72,6 +73,7 @@ gem "rails-autocomplete", "~> 2"
 gem "rails-i18n"
 gem "rbnacl", "~> 7.1"
 gem "redis", "~> 5.4"
+gem "romaji", "~> 0.3.0"
 gem "roo", "~> 2"
 gem "rorvswild"
 gem "rswag", "~> 2"
@@ -87,6 +89,7 @@ gem "summernote-rails", git: "https://github.com/noesya/summernote-rails.git", b
 # gem "summernote-rails", path: "../../noesya/summernote-rails"
 gem "two_factor_authentication", git: "https://github.com/noesya/two_factor_authentication.git"
 # gem "two_factor_authentication", path: "../two_factor_authentication"
+gem "tzinfo-data", platforms: [:windows, :jruby]
 # gem "unsplash", "~> 3"
 gem "unsplash", git: "https://github.com/SebouChu/unsplash_rb.git", branch: 'ruby-4-compatibility'
 gem "vimeo"
@@ -116,5 +119,3 @@ group :test do
   gem "webdrivers"
   gem "simplecov", require: false
 end
-
-gem "tzinfo-data", platforms: [:windows, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
+    babosa (2.1.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
     better_errors (2.10.1)
@@ -468,6 +469,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nkf (0.3.0)
     nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
@@ -614,6 +616,9 @@ GEM
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
+    romaji (0.3.0)
+      nkf (>= 0.2.0)
+      rake (>= 0.8.0)
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -783,6 +788,7 @@ DEPENDENCIES
   add_to_calendar
   annotaterb
   aws-sdk-s3
+  babosa (~> 2.1)
   better_errors
   binding_of_caller
   bootsnap (~> 1)
@@ -849,6 +855,7 @@ DEPENDENCIES
   rails-i18n
   rbnacl (~> 7.1)
   redis (~> 5.4)
+  romaji (~> 0.3.0)
   roo (~> 2)
   rorvswild
   rspec-rails

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -14,7 +14,7 @@ module Sluggable
   end
 
   def set_slug
-    self.slug = to_s.parameterize if self.slug.blank?
+    self.slug = generate_slug_from_to_s if self.slug.blank?
     adjust_slug_length
     current_slug = self.slug
     n = 0
@@ -25,6 +25,11 @@ module Sluggable
   end
 
   protected
+
+  def generate_slug_from_to_s
+    slug = to_s.to_slug.normalize.to_s
+    Romaji.kana2romaji(slug)
+  end
 
   def adjust_slug_length
     return unless self.slug.length > SLUG_MAX_LENGTH

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -19,8 +19,23 @@ class SluggableTest < ActiveSupport::TestCase
     orga_l10n.set_slug
     assert_equal "un-nom-dentreprise-avec-caracteres-speciaux-123", orga_l10n.slug, "Special chars are removed"
 
+    # TODO: Handle Vietnamese
+    # orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les phở đặc biệt")
+    # orga_l10n.set_slug
+    # assert_equal "lart-de-cuisiner-les-pho-bac-biet", orga_l10n.slug, "Transliterate Vietnamese characters"
+
     orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les スシ")
     orga_l10n.set_slug
     assert_equal "lart-de-cuisiner-les-sushi", orga_l10n.slug, "Transliterate Kana characters"
+
+    # TODO: Handle Russian
+    # orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les суши")
+    # orga_l10n.set_slug
+    # assert_equal "lart-de-cuisiner-les-sushi", orga_l10n.slug, "Transliterate Cyrillic characters"
+
+    # TODO: Handle Hindi
+    # orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les सूशी")
+    # orga_l10n.set_slug
+    # assert_equal "lart-de-cuisiner-les-sushi", orga_l10n.slug, "Transliterate Hindi characters"
   end
 end

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+# Pour tester juste ce jeu `rake test TEST=test/models/concerns/sluggable_test.rb`
+class SluggableTest < ActiveSupport::TestCase
+  def test_slugs
+    orga_l10n = University::Organization::Localization.new(
+      university: default_university,
+      language: french,
+      name: "Entreprise"
+    )
+    orga_l10n.set_slug
+    assert_equal "entreprise", orga_l10n.slug, "Simple slug"
+
+    orga_l10n.assign_attributes(slug: nil, name: "noesya")
+    orga_l10n.set_slug
+    assert_equal "noesya-1", orga_l10n.slug, "Duplicate slug adds “-1”"
+
+    orga_l10n.assign_attributes(slug: nil, name: "Un nom d'entreprise avec caractères spéciaux 123")
+    orga_l10n.set_slug
+    assert_equal "un-nom-dentreprise-avec-caracteres-speciaux-123", orga_l10n.slug, "Special chars are removed"
+
+    orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les スシ")
+    orga_l10n.set_slug
+    assert_equal "lart-de-cuisiner-les-sushi", orga_l10n.slug, "Transliterate Kana characters"
+  end
+end


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Utilisation des gems `babosa` et `romaji` pour gérer la génération de slugs pour les caractères non-latins. `romaji` gère le japonais, et `babosa` gère les langues suivantes :

- Bulgare
- Danois
- Allemand
- Grec
- Hindi
- Macédonien
- Norvégien
- Roumain
- Russe
- Serbe
- Espagnol
- Suédois
- Turc
- Ukrainien
- Vietnamien

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
