### PR TITLE
Pas de slash final après les redirections qui finissent en .html

### DIFF
--- a/app/services/static.rb
+++ b/app/services/static.rb
@@ -12,8 +12,13 @@ class Static
     clean_path = path.dup
     # Leading slash for absolute path
     clean_path = "/#{clean_path}" unless clean_path.start_with?('/')
-    # Trailing slash for consistency
-    clean_path += '/' unless clean_path.end_with?('/')
+    if clean_path.end_with?('.html')
+      # For redirections based on old websites
+      # We don't do anything
+    else
+      # Trailing slash for consistency
+      clean_path += '/' unless clean_path.end_with?('/')
+    end
     clean_path.gsub('//', '/')
   end
 

--- a/app/services/static.rb
+++ b/app/services/static.rb
@@ -15,9 +15,9 @@ class Static
     if clean_path.end_with?('.html')
       # For redirections based on old websites
       # We don't do anything
-    else
+    elsif !clean_path.end_with?('/')
       # Trailing slash for consistency
-      clean_path += '/' unless clean_path.end_with?('/')
+      clean_path += '/'
     end
     clean_path.gsub('//', '/')
   end


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Quand une redirection est créée, terminant par `.html`, on n'ajoute pas de `/` à la fin

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
