### PR TITLE
Remplacement des underscores dans la génération des slugs

### DIFF
--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -28,6 +28,7 @@ module Sluggable
 
   def generate_slug_from_to_s
     slug = to_s.to_slug.normalize.to_s
+    slug.gsub!("_", "-")
     Romaji.kana2romaji(slug)
   end
 

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -19,6 +19,10 @@ class SluggableTest < ActiveSupport::TestCase
     orga_l10n.set_slug
     assert_equal "un-nom-dentreprise-avec-caracteres-speciaux-123", orga_l10n.slug, "Special chars are removed"
 
+    orga_l10n.assign_attributes(slug: nil, name: "un-nom-de-fichier_avec_underscores.pdf")
+    orga_l10n.set_slug
+    assert_equal "un-nom-de-fichier-avec-underscorespdf", orga_l10n.slug, "Underscores are replaced"
+
     # TODO: Handle Vietnamese
     # orga_l10n.assign_attributes(slug: nil, name: "L'art de cuisiner les phở đặc biệt")
     # orga_l10n.set_slug


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Correction des underscores dans les slugs pour les remplacer par des tirets

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
