### PR TITLE
job: fix search scope (summary instead of description)

### DIFF
--- a/app/models/communication/website/jobboard/job.rb
+++ b/app/models/communication/website/jobboard/job.rb
@@ -62,7 +62,7 @@ class Communication::Website::Jobboard::Job < ApplicationRecord
       .where(communication_website_jobboard_job_localizations: { language_id: language.id })
       . where("
       unaccent(communication_website_jobboard_job_localizations.meta_description) ILIKE unaccent(:term) OR
-      unaccent(communication_website_jobboard_job_localizations.description) ILIKE unaccent(:term) OR
+      unaccent(communication_website_jobboard_job_localizations.summary) ILIKE unaccent(:term) OR
       unaccent(communication_website_jobboard_job_localizations.title) ILIKE unaccent(:term) OR
       unaccent(communication_website_jobboard_job_localizations.subtitle) ILIKE unaccent(:term)
     ", term: "%#{sanitize_sql_like(term)}%")


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans le scope de recherche de Job, on vise summary plutôt que description (qui n'existe pas)

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
