### PR TITLE
Service de vérification de l'intégrité des fichiers d'un repository GitHub

### DIFF
--- a/app/jobs/communication/website/check_git_files_integrity_job.rb
+++ b/app/jobs/communication/website/check_git_files_integrity_job.rb
@@ -1,0 +1,8 @@
+class Communication::Website::CheckGitFilesIntegrityJob < Communication::Website::BaseJob
+  queue_as :elephants
+
+  def execute
+    website.check_git_files_integrity_safely
+  end
+
+end

--- a/app/models/communication/website/git_file.rb
+++ b/app/models/communication/website/git_file.rb
@@ -43,6 +43,7 @@ class Communication::Website::GitFile < ApplicationRecord
   validates :about_id, uniqueness: { scope: [:about_type, :website_id] }, allow_nil: true
 
   scope :generated, -> { where.not(generated_at: nil) }
+  scope :synchronized, -> { where(desynchronized: false) }
   scope :desynchronized, -> { where(desynchronized: true) }
   scope :desynchronized_since, -> (time) { desynchronized.where('desynchronized_at > ?', time) }
   scope :desynchronized_until, -> (time) { desynchronized.where('desynchronized_at <= ?', time) }

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -110,24 +110,24 @@ module Communication::Website::WithGitRepository
     git_repository.update_theme_version!
   end
 
-  def analyse_repository_safely
-    return unless git_repository.valid?
-    Git::OrphanAndLayoutAnalyzer.new(self).launch
-  end
-
   def analyse_repository
     return unless git_repository.valid?
     Communication::Website::AnalyseJob.perform_later(id)
   end
 
-  def check_git_files_integrity_safely
+  def analyse_repository_safely
     return unless git_repository.valid?
-    Git::FilesIntegrityChecker.new(self).launch
+    Git::OrphanAndLayoutAnalyzer.new(self).launch
   end
 
   def check_git_files_integrity
     return unless git_repository.valid?
     Communication::Website::CheckGitFilesIntegrityJob.perform_later(id)
+  end
+
+  def check_git_files_integrity_safely
+    return unless git_repository.valid?
+    Git::FilesIntegrityChecker.new(self).launch
   end
 
   def desynchronized_generated_git_files

--- a/app/models/communication/website/with_git_repository.rb
+++ b/app/models/communication/website/with_git_repository.rb
@@ -120,6 +120,16 @@ module Communication::Website::WithGitRepository
     Communication::Website::AnalyseJob.perform_later(id)
   end
 
+  def check_git_files_integrity_safely
+    return unless git_repository.valid?
+    Git::FilesIntegrityChecker.new(self).launch
+  end
+
+  def check_git_files_integrity
+    return unless git_repository.valid?
+    Communication::Website::CheckGitFilesIntegrityJob.perform_later(id)
+  end
+
   def desynchronized_generated_git_files
     git_files_list = git_files.generated
     last_sync_at.nil? ? git_files_list.desynchronized

--- a/app/services/git/files_integrity_checker.rb
+++ b/app/services/git/files_integrity_checker.rb
@@ -1,0 +1,66 @@
+class Git::FilesIntegrityChecker
+  attr_reader :website, :dry_run, :git_files_to_desynchronize
+
+  def initialize(website, dry_run: false)
+    @website = website
+    @dry_run = dry_run
+    @git_files_to_desynchronize = []
+  end
+
+  def launch
+    return unless repository.valid? && repository.can_check_git_files_integrity?
+    website.git_files.synchronized.find_each do |git_file|
+      check_integrity!(git_file)
+    end
+    puts "Found #{git_files_to_desynchronize.size} git files to desynchronize."
+    website.sync_with_git if should_sync_website?
+  end
+
+  protected
+
+  def check_integrity!(git_file)
+    if missing_git_file?(git_file)
+      puts "Missing GitFile #{git_file.id}"
+      puts "- path: #{git_file.current_path}"
+      desynchronize!(git_file)
+    elsif outdated_git_file?(git_file)
+      puts "Outdated GitFile #{git_file.id}"
+      puts "- path: #{git_file.current_path}"
+      puts "- current sha: #{git_file.current_sha}"
+      puts "- remote sha: #{repository.git_sha(git_file.current_path)}"
+      desynchronize!(git_file)
+    end
+  end
+
+  def desynchronize!(git_file)
+    @git_files_to_desynchronize << git_file
+    git_file.update(
+      # Note the Git File as desynchronized...
+      desynchronized: true,
+      desynchronized_at: Time.current,
+      # ...and nullify previous SHA to force Git to send the file
+      previous_sha: nil
+    ) unless dry_run
+  end
+
+  def missing_git_file?(git_file)
+    !files_in_the_repository.include?(git_file.current_path)
+  end
+
+  def outdated_git_file?(git_file)
+    git_file.current_sha != repository.git_sha(git_file.current_path)
+  end
+
+  def should_sync_website?
+    git_files_to_desynchronize.any? && !dry_run
+  end
+
+  def repository
+    @repository ||= website.git_repository
+  end
+
+  def files_in_the_repository
+    @files_in_the_repository ||= repository.files_in_the_repository
+  end
+
+end

--- a/app/services/git/providers/abstract.rb
+++ b/app/services/git/providers/abstract.rb
@@ -53,6 +53,10 @@ class Git::Providers::Abstract
     []
   end
 
+  def can_check_git_files_integrity?
+    false
+  end
+
   protected
 
   def batch

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -126,6 +126,10 @@ class Git::Providers::Github < Git::Providers::Abstract
     @files_in_the_repository ||= tree[:tree].map { |file| file[:path] }
   end
 
+  def can_check_git_files_integrity?
+    !tree[:truncated]
+  end
+
   protected
 
   def check_batch_integrity!

--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -126,6 +126,9 @@ class Git::Providers::Github < Git::Providers::Abstract
     @files_in_the_repository ||= tree[:tree].map { |file| file[:path] }
   end
 
+  # The limit for the tree array is 100,000 entries.
+  # If it contains more, the tree is returned as truncated, so we can't use it for checking.
+  # https://docs.github.com/fr/rest/git/trees?apiVersion=2026-03-10#get-a-tree
   def can_check_git_files_integrity?
     !tree[:truncated]
   end

--- a/app/services/git/repository.rb
+++ b/app/services/git/repository.rb
@@ -56,6 +56,10 @@ class Git::Repository
     provider.files_in_the_repository
   end
 
+  def can_check_git_files_integrity?
+    provider.can_check_git_files_integrity?
+  end
+
   protected
 
   def provider


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'un service (+ job) pour vérifier l'intégrité des GitFiles d'un site.

A partir du Git Tree, on vérifie pour chaque Git File s'il a besoin d'être re-synchronisé de force. On compare directement avec les informations venant de Git pour vérifier la présence et le SHA du fichier.

Actuellement, ne fonctionne qu'avec les repos hébergés sur GitHub.

Devrait corriger les pages dont les médias ou les fichiers manqueraient, mais peut également mettre à jour des pages obsolètes qui n'ont pas été rafraichies depuis quelque temps.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [x] Aucun 😌
- [ ] Changements mineurs 😲
- [ ] Changments majeurs 😱
