### PR TITLE
Migration des logos d'organisations non enregistrées

### DIFF
--- a/app/jobs/unicorns_job.rb
+++ b/app/jobs/unicorns_job.rb
@@ -3,7 +3,6 @@ class UnicornsJob < ApplicationJob
   queue_as :unicorns
 
   def perform
-    Migrations::BlockTitlesToFiles.migrate
-    Migrations::CleanOrphanAttachments.migrate
+    Migrations::OrganizationsBlocksLogosToMedias.migrate
   end
 end

--- a/app/models/communication/block/template/feature/element.rb
+++ b/app/models/communication/block/template/feature/element.rb
@@ -18,12 +18,8 @@ class Communication::Block::Template::Feature::Element < Communication::Block::T
     image_component.communication_media
   end
 
-  def communication_media_l10n
-    communication_media.localization_for(block.language)
-  end
-
   def dom_count
-    2 + 
+    2 +
     description_component.dom_count +
     image_component.dom_count +
     alt_component.dom_count +

--- a/app/models/communication/block/template/gallery/element.rb
+++ b/app/models/communication/block/template/gallery/element.rb
@@ -12,10 +12,6 @@ class Communication::Block::Template::Gallery::Element < Communication::Block::T
     image_component.communication_media
   end
 
-  def communication_media_l10n
-    communication_media.localization_for(block.language)
-  end
-
   def check_accessibility
     super
     accessibility_warning 'accessibility.commons.alt.empty' if image_component.blob && alt.blank?

--- a/app/models/communication/block/template/key_figure/element.rb
+++ b/app/models/communication/block/template/key_figure/element.rb
@@ -13,10 +13,6 @@ class Communication::Block::Template::KeyFigure::Element < Communication::Block:
     image_component.communication_media
   end
 
-  def communication_media_l10n
-    communication_media.localization_for(block.language)
-  end
-
   def dom_count
     5 +
     image_component.dom_count

--- a/app/models/communication/block/template/link/element.rb
+++ b/app/models/communication/block/template/link/element.rb
@@ -23,12 +23,8 @@ class Communication::Block::Template::Link::Element < Communication::Block::Temp
     image_component.communication_media
   end
 
-  def communication_media_l10n
-    communication_media.localization_for(block.language)
-  end
-
   def dom_count
-    1 + 
+    1 +
     title_component.dom_count +
     description_component.dom_count +
     url_component.dom_count +

--- a/app/models/communication/block/template/organization.rb
+++ b/app/models/communication/block/template/organization.rb
@@ -35,6 +35,11 @@ class Communication::Block::Template::Organization < Communication::Block::Templ
     @elements
   end
 
+  # Permet de gérer les contextes
+  def communication_medias
+    elements.map(&:communication_media).compact_blank
+  end
+
   def dependencies
     selected_elements
   end

--- a/app/models/communication/block/template/organization/element.rb
+++ b/app/models/communication/block/template/organization/element.rb
@@ -44,8 +44,12 @@ class Communication::Block::Template::Organization::Element < Communication::Blo
     organization_l10n.logo&.blob
   end
 
+  def communication_media
+    logo_component.communication_media
+  end
+
   def dom_count
-    2 + 
+    2 +
     name_component.dom_count +
     url_component.dom_count +
     logo_component.dom_count +

--- a/app/models/communication/block/template/testimonial/element.rb
+++ b/app/models/communication/block/template/testimonial/element.rb
@@ -17,10 +17,6 @@ class Communication::Block::Template::Testimonial::Element < Communication::Bloc
     photo_component.communication_media
   end
 
-  def communication_media_l10n
-    communication_media.localization_for(block.language)
-  end
-
   def dom_count
     2 +
     text_component.dom_count +

--- a/app/models/communication/media.rb
+++ b/app/models/communication/media.rb
@@ -182,9 +182,10 @@ class Communication::Media < ApplicationRecord
     )
   end
 
-  def find_or_create_localization(language, alt: nil, credit: nil)
+  def find_or_create_localization(language, name: nil, alt: nil, credit: nil)
     localizations.where(language: language)
                 .first_or_create do |l10n|
+      l10n.name = name
       l10n.alt = alt
       l10n.credit = credit
       l10n.published = true

--- a/app/services/migrations/organizations_blocks_logos_to_medias.rb
+++ b/app/services/migrations/organizations_blocks_logos_to_medias.rb
@@ -1,0 +1,51 @@
+class Migrations::OrganizationsBlocksLogosToMedias
+  def self.migrate
+    Communication::Block.where(template_kind: :organizations).with_deleted.find_each do |block|
+      data = block.data.dup
+      something_to_migrate = false
+      (data['elements'] || []).each do |element|
+        next unless element.is_a?(Hash)
+        # {
+        #   "id" => "",
+        #   "name" => "Université de Rennes",
+        #   "url" => "https://www.univ-rennes.fr/",
+        #   "logo" => {
+        #     "id" => "<uuid>",
+        #     "filename" => "Universite_de_Rennes.svg",
+        #     "signed_id" => "<signed_id"
+        #   },
+        #   "role" => ""
+        # }
+        name = element['name'].presence
+        logo = element['logo']
+        next unless logo.is_a?(Hash)
+        blob_id = logo['id']
+        next unless blob_id.present?
+        # Déjà migré
+        next if logo['communication_media_id']
+        media = blob_to_media(block, blob_id, name)
+        # Pas de blob, donc pas de média
+        next if media.nil?
+        something_to_migrate = true
+        logo['communication_media_id'] = media.id
+      end
+      next unless something_to_migrate
+      block.data = data
+      block.save
+      puts "Block #{block.id} migrated"
+    end
+  end
+
+  protected
+
+  def self.blob_to_media(block, blob_id, name)
+    blob = ActiveStorage::Blob.find_by(id: blob_id)
+    # Blob absent
+    return if blob.nil?
+    media = Communication::Media.find_or_create_media_from_blob(blob)
+    media_l10n = media.find_or_create_localization(block.language, name: name)
+    media.add_context(block)
+    media
+  end
+
+end

--- a/app/views/admin/communication/blocks/templates/organizations/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/organizations/_edit.html.erb
@@ -25,7 +25,7 @@ object_endpoint = admin_university_organizations_path
   </a>
   <a
     class="<%= button_classes %>"
-    @click="data.elements.push({})">
+    @click="addElement()">
     <%= t('.add_organization_unregistered') %>
   </a>
 
@@ -103,7 +103,7 @@ object_endpoint = admin_university_organizations_path
     </a>
     <a
       class="<%= button_classes %>"
-      @click="data.elements.push({})">
+      @click="addElement()">
       <%= t('.add_organization_unregistered') %>
     </a>
   </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Migration des logos d'organisations non enregistrées contenus dans les blocs Organisations vers la photothèque

Correction de la création d'organisation non enregistrée

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [x] Aucun 😌
- [ ] Changements mineurs 😲
- [ ] Changements majeurs 😱
