### PR TITLE
On ne demande plus la photo de profil à l'inscription sur l'extranet si on vient d'une invitation et que la personne invitée a déjà une photo

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -53,11 +53,14 @@
                   compare_with_field: :password,
                   input_html: { autocomplete: "new-password" } %>
       <%= f.input :mobile_phone %>
-      <%= f.input :picture,
-                        as: :single_deletable_file,
-                        input_html: { accept: default_images_formats_accepted },
-                        preview: 200,
-                        resize: 1 %>
+
+      <% unless resource.invitation&.person&.picture&.attached? %>
+        <%= f.input :picture,
+                    as: :single_deletable_file,
+                    input_html: { accept: default_images_formats_accepted },
+                    preview: 200,
+                    resize: 1 %>
+      <% end %>
     </div>
   </div>
   <%= f.button :submit, t(".sign_up"), class: 'btn btn-primary' %>


### PR DESCRIPTION


## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
A la demande d'Igor pour l'extranet GCCD, lorsqu'une personne est invitée et qu'elle vient s'inscrire, on ne demande pas de photo de profil si elle en a déjà une


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [ ] Aucun 😌
- [x] Changements mineurs 😲
- [ ] Changements majeurs 😱
