### PR TITLE
Correction de l'original_guessed_name quand il n'y a pas d'original_filename

### DIFF
--- a/app/models/concerns/has_original_blob.rb
+++ b/app/models/concerns/has_original_blob.rb
@@ -27,7 +27,7 @@ module HasOriginalBlob
   end
 
   def original_guessed_name
-    File.basename(original_filename, ".*").humanize
+    File.basename(original_filename.to_s, ".*").humanize
   end
 
   def max_file_size


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

FIx #4339

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [x] Aucun 😌
- [ ] Changements mineurs 😲
- [ ] Changements majeurs 😱
