### PR TITLE
A la suppression d'une image dans un composant de bloc, on supprime l'ID legacy

### DIFF
--- a/app/views/admin/communication/blocks/components/image/_edit.html.erb
+++ b/app/views/admin/communication/blocks/components/image/_edit.html.erb
@@ -13,5 +13,6 @@
   v-model="<%= model %>.<%= property %>.communication_media_id"
   @picked="<%= model %>.alt = $event.alt"
   @cropped="<%= model %>.<%= property %>.crop_settings = $event"
+  @unselected="<%= model %>.<%= property %>.id = ''"
   >
 </media-input>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

A la suppression d'une image dans un composant de bloc, on supprime l'ID legacy.

Cela faisait un conflit avec le before_validation qui tente de rebrancher un media

On l'a conservé pour la migration (non destructive)

Corrige https://github.com/osunyorg/campus-art-mediterranee/issues/65

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [x] Aucun 😌
- [ ] Changements mineurs 😲
- [ ] Changements majeurs 😱
