### PR TITLE
Le migration_identifier doit être vidé à la duplication/copie/traduction

### DIFF
--- a/app/controllers/admin/communication/blocks_controller.rb
+++ b/app/controllers/admin/communication/blocks_controller.rb
@@ -63,7 +63,7 @@ class Admin::Communication::BlocksController < Admin::Communication::Application
   end
 
   def duplicate
-    @block = @block.duplicate
+    @block = @block.duplicate(keep_position: true)
     head :ok
   end
 

--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -100,11 +100,11 @@ class Communication::Block < ApplicationRecord
     @language ||= about.language
   end
 
-  def duplicate(to: about, reset_position: true)
+  def duplicate(to: about, keep_position: false)
     block = self.dup
     block.about = to
     block.migration_identifier = nil
-    block.position = nil if reset_position
+    block.position = nil unless keep_position
     block.save
     block
   end
@@ -114,7 +114,7 @@ class Communication::Block < ApplicationRecord
   end
 
   def localize_for!(new_localization)
-    duplicate(to: new_localization, reset_position: false)
+    duplicate(to: new_localization, keep_position: true)
   end
 
   def empty?

--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -100,24 +100,21 @@ class Communication::Block < ApplicationRecord
     @language ||= about.language
   end
 
-  def duplicate
+  def duplicate(to: about, reset_position: true)
     block = self.dup
+    block.about = to
+    block.migration_identifier = nil
+    block.position = nil if reset_position
     block.save
     block
   end
 
   def paste(about)
-    block = self.dup
-    block.about = about
-    block.position = nil # Will be computed on save
-    block.save
-    block
+    duplicate(to: about)
   end
 
   def localize_for!(new_localization)
-    localized_block = self.dup
-    localized_block.about = new_localization
-    localized_block.save
+    duplicate(to: new_localization, reset_position: false)
   end
 
   def empty?

--- a/app/models/concerns/as_localization.rb
+++ b/app/models/concerns/as_localization.rb
@@ -47,6 +47,8 @@ module AsLocalization
     # Localized should not be published immediately
     l10n.published = false if respond_to?(:published)
 
+    l10n.migration_identifier = nil if respond_to?(:migration_identifier)
+
     localize_other_attachments(l10n)
 
     # Blocks need an about, so we save before localizing blocks

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -15,7 +15,7 @@ module Duplicable
   def duplicate_blocks(from, to)
     return unless from.respond_to?(:blocks)
     from.blocks.ordered.each do |block|
-      duplicate_block(to, block)
+      block.duplicate(to: to)
     end
   end
 
@@ -23,6 +23,7 @@ module Duplicable
 
   def duplicate_instance
     instance = self.dup
+    instance.migration_identifier = nil if instance.respond_to?(:migration_identifier)
     instance.position = nil if instance.respond_to?(:position)
     instance.save
     instance
@@ -39,17 +40,11 @@ module Duplicable
       instance_l10n.about = instance
       # note: fragile. It only works because every duplicate objects currently has a "title" property.
       instance_l10n.title = I18n.t('copy_of', title: l10n.title)
+      instance_l10n.migration_identifier = nil if instance_l10n.respond_to?(:migration_identifier)
       instance_l10n.published = false if instance_l10n.respond_to?(:published)
       instance_l10n.published_at = nil if instance_l10n.respond_to?(:published_at)
       instance_l10n.save
       duplicate_blocks(l10n, instance_l10n)
     end
-  end
-
-  def duplicate_block(instance, block)
-    duplicated_block = block.dup
-    duplicated_block.about = instance
-    duplicated_block.position = block.position
-    duplicated_block.save
   end
 end

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -15,7 +15,7 @@ module Duplicable
   def duplicate_blocks(from, to)
     return unless from.respond_to?(:blocks)
     from.blocks.ordered.each do |block|
-      block.duplicate(to: to)
+      block.duplicate(to: to, keep_position: true)
     end
   end
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

>[!NOTE]
> Testé !

Le migration_identifier doit être vidé à la duplication/copie/traduction

Un peu de refactoring

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Changement d'interface

- [x] Aucun 😌
- [ ] Changements mineurs 😲
- [ ] Changements majeurs 😱
